### PR TITLE
Standardize capitalization in site hero and mission

### DIFF
--- a/edc_site/index.html
+++ b/edc_site/index.html
@@ -29,7 +29,7 @@
   <!-- Hero Section -->
   <section class="hero" id="home" style="background-image: url('images/new_graphics/network_1.png');">
     <div class="hero-overlay">
-      <h1>We connect European PEOPLE AND business</h1>
+      <h1>We connect European people and business</h1>
       <p>We bring European professionals together</p>
     </div>
   </section>
@@ -38,7 +38,7 @@
   <section class="mission" id="mission">
     <div class="container">
       <h2>Our Mission</h2>
-      <p class="lead">We are the voice of the European VW/AUDI dealers and service partners</p>
+      <p class="lead">We are the voice of the European VW/Audi dealers and service partners</p>
       <div class="cards">
         <div class="card">
           <h3>Founding</h3>


### PR DESCRIPTION
## Summary
- Update hero heading to use consistent sentence case
- Align mission statement text with standard brand capitalization

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689da24104dc8330be3d0b1e9314f326