### PR TITLE
Improve Latest News image display

### DIFF
--- a/edc_site/styles.css
+++ b/edc_site/styles.css
@@ -218,8 +218,9 @@ body {
 
 .news-item img {
   width: 100%;
-  height: 200px;
-  object-fit: cover;
+  height: auto;
+  object-fit: contain;
+  display: block;
 }
 
 .news-item h3 {


### PR DESCRIPTION
## Summary
- avoid cropping in Latest News section by letting images keep natural proportions

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689da42591ac8330929ffd8407bc6057