### PR TITLE
Add slideshow news item for 70th EDC Conference 2025

### DIFF
--- a/edc_site/index.html
+++ b/edc_site/index.html
@@ -113,6 +113,21 @@
       <h2>Latest News</h2>
       <div class="news-grid">
         <article class="news-item">
+          <div class="slideshow">
+            <img src="images/edc70/L1331163.jpg" alt="70th EUROPEAN DEALER COUNCIL Conference 2025 in Luxembourg">
+            <img src="images/edc70/L1331191.jpg" alt="70th EUROPEAN DEALER COUNCIL Conference 2025 in Luxembourg">
+            <img src="images/edc70/L1331292.jpg" alt="70th EUROPEAN DEALER COUNCIL Conference 2025 in Luxembourg">
+            <img src="images/edc70/L1331305.jpg" alt="70th EUROPEAN DEALER COUNCIL Conference 2025 in Luxembourg">
+            <img src="images/edc70/L1331545.jpg" alt="70th EUROPEAN DEALER COUNCIL Conference 2025 in Luxembourg">
+            <img src="images/edc70/L1331561.jpg" alt="70th EUROPEAN DEALER COUNCIL Conference 2025 in Luxembourg">
+            <img src="images/edc70/L1331797.jpg" alt="70th EUROPEAN DEALER COUNCIL Conference 2025 in Luxembourg">
+            <img src="images/edc70/L1331819.jpg" alt="70th EUROPEAN DEALER COUNCIL Conference 2025 in Luxembourg">
+            <img src="images/edc70/L1331877.jpg" alt="70th EUROPEAN DEALER COUNCIL Conference 2025 in Luxembourg">
+          </div>
+          <h3>70th EUROPEAN DEALER COUNCIL Conference 2025 in Luxembourg</h3>
+          <time datetime="2025-05-01">May 2025</time>
+        </article>
+        <article class="news-item">
           <!-- Local copy of the conference image -->
           <img src="images/ed_berlin_vorstand.jpeg" alt="69th EDC Conference in Berlin on December 11 and 12, 2024">
           <h3>69th EDC Conference in Berlin on December 11 and 12, 2024</h3>
@@ -154,5 +169,6 @@
     </div>
   </footer>
 
+<script src="slideshow.js"></script>
 </body>
 </html>

--- a/edc_site/slideshow.js
+++ b/edc_site/slideshow.js
@@ -1,0 +1,13 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.slideshow').forEach(container => {
+    const images = container.querySelectorAll('img');
+    let index = 0;
+    if (images.length === 0) return;
+    images[index].classList.add('active');
+    setInterval(() => {
+      images[index].classList.remove('active');
+      index = (index + 1) % images.length;
+      images[index].classList.add('active');
+    }, 3000);
+  });
+});

--- a/edc_site/styles.css
+++ b/edc_site/styles.css
@@ -223,6 +223,18 @@ body {
   display: block;
 }
 
+.news-item .slideshow {
+  position: relative;
+}
+
+.news-item .slideshow img {
+  display: none;
+}
+
+.news-item .slideshow img.active {
+  display: block;
+}
+
 .news-item h3 {
   padding: 15px 20px 5px;
   font-size: 1.2rem;


### PR DESCRIPTION
## Summary
- add Latest News entry for the 70th European Dealer Council Conference in Luxembourg with all conference photos cycling every three seconds
- implement simple slideshow styling and JavaScript to rotate images automatically

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689da943bafc8330ab819dda422b6dec