### PR TITLE
Add interactive dealer map

### DIFF
--- a/edc_site/index.html
+++ b/edc_site/index.html
@@ -20,6 +20,7 @@
           <li><a href="#mission">Mission</a></li>
           <li><a href="#presidium">Presidium</a></li>
           <li><a href="#news">News</a></li>
+          <li><a href="map.html">Map</a></li>
           <li><a href="#contact">Contact</a></li>
         </ul>
       </nav>

--- a/edc_site/map.html
+++ b/edc_site/map.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dealer Map - European Dealer Council</title>
+  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+</head>
+<body>
+  <header class="navbar">
+    <div class="container nav-container">
+      <a href="index.html#home" class="logo">
+        <img src="images/edc_logo.jpeg" alt="European Dealer Council logo">
+      </a>
+      <nav>
+        <ul>
+          <li><a href="index.html#home">Home</a></li>
+          <li><a href="index.html#mission">Mission</a></li>
+          <li><a href="index.html#presidium">Presidium</a></li>
+          <li><a href="index.html#news">News</a></li>
+          <li><a href="map.html">Map</a></li>
+          <li><a href="index.html#contact">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <div id="map"></div>
+
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script>
+    const map = L.map('map').setView([54, 15], 4);
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(map);
+
+    Promise.all([
+      fetch('json/europe.geojson').then(r => r.json()),
+      fetch('json/dealers.json').then(r => r.json())
+    ]).then(([geoData, dealers]) => {
+      L.geoJSON(geoData, {
+        pointToLayer: function(feature, latlng) {
+          return L.circleMarker(latlng, {
+            radius: 5,
+            color: '#007BFF',
+            fillColor: '#007BFF',
+            fillOpacity: 0.8
+          });
+        },
+        onEachFeature: function(feature, layer) {
+          const iso = feature.properties.iso_a2;
+          const info = dealers[iso];
+          if (info) {
+            const content = `<strong>${info.country}</strong><br>Audi: ${info.audi}<br>VW: ${info.vw}`;
+            layer.bindPopup(content);
+            layer.on('mouseover', function() { this.openPopup(); });
+            layer.on('mouseout', function() { this.closePopup(); });
+          }
+        }
+      }).addTo(map);
+    });
+  </script>
+</body>
+</html>
+

--- a/edc_site/styles.css
+++ b/edc_site/styles.css
@@ -294,3 +294,7 @@ footer a {
   color: #ffffff;
   font-size: 0.9rem;
 }
+
+#map {
+  height: 600px;
+}


### PR DESCRIPTION
## Summary
- add Map link in top navigation
- create Leaflet-powered dealer map using europe.geojson and dealers.json
- style map container

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/EDC/package.json')*

------
https://chatgpt.com/codex/tasks/task_b_689daa6c00e883308ebb3aaa10d2a260