### PR TITLE
Add title and enlarge dealer map popups

### DIFF
--- a/edc_site/map.html
+++ b/edc_site/map.html
@@ -26,7 +26,11 @@
     </div>
   </header>
 
-  <div id="map"></div>
+  <main class="map-section">
+    <h1>European Dealers of Audi and Volkswagen Brand</h1>
+    <p class="map-instruction">Move cursor of your mouse over country main city</p>
+    <div id="map"></div>
+  </main>
 
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script>
@@ -54,7 +58,7 @@
           const info = dealers[iso];
           if (info) {
             const content = `<strong>${info.country}</strong><br>Audi: ${info.audi}<br>VW: ${info.vw}`;
-            layer.bindPopup(content);
+            layer.bindPopup(content, { className: 'dealer-popup', maxWidth: 400 });
             layer.on('mouseover', function() { this.openPopup(); });
             layer.on('mouseout', function() { this.closePopup(); });
           }

--- a/edc_site/styles.css
+++ b/edc_site/styles.css
@@ -310,3 +310,25 @@ footer a {
 #map {
   height: 600px;
 }
+
+.map-section {
+  text-align: center;
+  padding: 20px;
+}
+
+.map-section h1 {
+  font-size: 2rem;
+  color: #003366;
+  margin-bottom: 0.5rem;
+}
+
+.map-instruction {
+  font-size: 1rem;
+  color: #555;
+  margin-bottom: 1rem;
+}
+
+.dealer-popup .leaflet-popup-content-wrapper {
+  font-size: 1.2rem;
+  padding: 15px;
+}


### PR DESCRIPTION
## Summary
- Add prominent "European Dealers of Audi and Volkswagen Brand" heading with instruction on the map page
- Enlarge dealer popups and text for clearer display
- Style map page with centered layout and popup formatting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689dad1761c0833098b2cde7f454441c