### PR TITLE
Add embedded map to homepage

### DIFF
--- a/edc_site/index.html
+++ b/edc_site/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>European Dealer Council</title>
   <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
 </head>
 <body>
   <!-- Navigation Bar -->
@@ -144,6 +145,13 @@
     </div>
   </section>
 
+  <!-- Map Section -->
+  <section class="map-section" id="map-section">
+    <h2>European Dealers of Audi and Volkswagen Brand</h2>
+    <p class="map-instruction">Move cursor of your mouse over country main city</p>
+    <div id="map"></div>
+  </section>
+
   <!-- Partners Section -->
   <section class="partners">
     <div class="container partners-grid">
@@ -170,6 +178,40 @@
     </div>
   </footer>
 
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<script>
+  const map = L.map('map').setView([54, 15], 4);
+
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; OpenStreetMap contributors'
+  }).addTo(map);
+
+  Promise.all([
+    fetch('json/europe.geojson').then(r => r.json()),
+    fetch('json/dealers.json').then(r => r.json())
+  ]).then(([geoData, dealers]) => {
+    L.geoJSON(geoData, {
+      pointToLayer: function(feature, latlng) {
+        return L.circleMarker(latlng, {
+          radius: 5,
+          color: '#007BFF',
+          fillColor: '#007BFF',
+          fillOpacity: 0.8
+        });
+      },
+      onEachFeature: function(feature, layer) {
+        const iso = feature.properties.iso_a2;
+        const info = dealers[iso];
+        if (info) {
+          const content = `<strong>${info.country}</strong><br>Audi: ${info.audi}<br>VW: ${info.vw}`;
+          layer.bindPopup(content, { className: 'dealer-popup', maxWidth: 400 });
+          layer.on('mouseover', function() { this.openPopup(); });
+          layer.on('mouseout', function() { this.closePopup(); });
+        }
+      }
+    }).addTo(map);
+  });
+</script>
 <script src="slideshow.js"></script>
 </body>
 </html>

--- a/edc_site/styles.css
+++ b/edc_site/styles.css
@@ -309,6 +309,7 @@ footer a {
 
 #map {
   height: 600px;
+  width: 100%;
 }
 
 .map-section {


### PR DESCRIPTION
## Summary
- Embed Leaflet-based dealer map on the homepage above partner logos
- Load Leaflet styles and scripts and ensure the map spans full width of the screen

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_689daf8d6180833081cdfe7d645616b4