### PR TITLE
Add dynamic hero banner slideshow

### DIFF
--- a/edc_site/hero-banner.js
+++ b/edc_site/hero-banner.js
@@ -1,0 +1,41 @@
+// Dynamically load hero background images from images/banner
+// Randomize order and rotate every 3 seconds
+
+document.addEventListener('DOMContentLoaded', () => {
+  const hero = document.querySelector('.hero');
+  if (!hero) return;
+
+  fetch('images/banner/')
+    .then(response => response.text())
+    .then(text => {
+      const doc = new DOMParser().parseFromString(text, 'text/html');
+      const files = Array.from(doc.querySelectorAll('a'))
+        .map(a => a.getAttribute('href'))
+        .filter(href => href && href.match(/\.(jpe?g|png|gif)$/i))
+        .map(name => `images/banner/${name}`);
+
+      if (files.length === 0) return;
+
+      // Shuffle the array for random order
+      for (let i = files.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [files[i], files[j]] = [files[j], files[i]];
+      }
+
+      // Preload images
+      files.forEach(src => {
+        const img = new Image();
+        img.src = src;
+      });
+
+      let index = 0;
+      hero.style.backgroundImage = `url('${files[index]}')`;
+      setInterval(() => {
+        index = (index + 1) % files.length;
+        hero.style.backgroundImage = `url('${files[index]}')`;
+      }, 3000);
+    })
+    .catch(err => {
+      console.error('Failed to load banner images', err);
+    });
+});

--- a/edc_site/hero-banner.js
+++ b/edc_site/hero-banner.js
@@ -5,13 +5,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const hero = document.querySelector('.hero');
   if (!hero) return;
 
-  fetch('images/banner/')
-    .then(response => response.text())
-    .then(text => {
-      const doc = new DOMParser().parseFromString(text, 'text/html');
-      const files = Array.from(doc.querySelectorAll('a'))
-        .map(a => a.getAttribute('href'))
-        .filter(href => href && href.match(/\.(jpe?g|png|gif)$/i))
+  fetch('./images/banner/banner-images.json')
+    .then(response => response.json())
+    .then(files => {
+      files = files
+        .filter(name => name.match(/\.(jpe?g|png|gif)$/i))
         .map(name => `images/banner/${name}`);
 
       if (files.length === 0) return;

--- a/edc_site/images/banner/banner-images.json
+++ b/edc_site/images/banner/banner-images.json
@@ -1,0 +1,1 @@
+["L1331163.jpg", "L1331191.jpg", "L1331292.jpg", "L1331305.jpg", "L1331545.jpg", "L1331561.jpg", "L1331797.jpg", "L1331819.jpg", "L1331877.jpg", "network_1.png", "network_2.png", "network_3.png"]

--- a/edc_site/index.html
+++ b/edc_site/index.html
@@ -29,7 +29,7 @@
   </header>
 
   <!-- Hero Section -->
-  <section class="hero" id="home" style="background-image: url('images/new_graphics/network_1.png');">
+  <section class="hero" id="home">
     <div class="hero-overlay">
       <h1>We connect European people and business</h1>
       <p>We bring European professionals together</p>
@@ -212,6 +212,7 @@
     }).addTo(map);
   });
 </script>
+<script src="hero-banner.js"></script>
 <script src="slideshow.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Rotate hero section background through images in `images/banner` automatically
- Load banner images dynamically in random order and change every 3 seconds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689dba02dc4c8330b43faf83b82ad2a0