### PR TITLE
Add admin page for banner uploads

### DIFF
--- a/edc_site/update.html
+++ b/edc_site/update.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8" />
+  <title>Aktualizacja banera</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    form { margin-bottom: 1rem; }
+    #uploader { display:none; }
+  </style>
+</head>
+<body>
+  <div id="login">
+    <h1>Panel administracyjny</h1>
+    <form id="loginForm">
+      <label for="password">Hasło:</label>
+      <input type="password" id="password" required />
+      <button type="submit">Zaloguj</button>
+    </form>
+    <p><a href="mailto:michal@ignasza.pl?subject=Reset%20has%C5%82a">Zapomniałem hasła</a></p>
+  </div>
+
+  <div id="uploader">
+    <h2>Dodaj zdjęcie do bannera</h2>
+    <form id="uploadForm" enctype="multipart/form-data" method="post">
+      <input type="file" name="banner" accept="image/*" required />
+      <input type="hidden" name="password" id="passwordHash" />
+      <button type="submit">Prześlij</button>
+    </form>
+    <div id="message"></div>
+  </div>
+
+  <script>
+    const PASSWORD_HASH = '37ba3d76293846ac3d3314714ef3a4438450b9c5ff48ab0c0252af9e2efe5285'; // sha256('edc_admin')
+
+    async function sha256(str) {
+      const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(str));
+      return Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2, '0')).join('');
+    }
+
+    const loginForm = document.getElementById('loginForm');
+    const uploadForm = document.getElementById('uploadForm');
+
+    loginForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const pass = document.getElementById('password').value;
+      const hash = await sha256(pass);
+      if (hash === PASSWORD_HASH) {
+        document.getElementById('login').style.display = 'none';
+        document.getElementById('uploader').style.display = 'block';
+        document.getElementById('passwordHash').value = hash;
+      } else {
+        alert('Błędne hasło');
+      }
+    });
+
+    uploadForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const formData = new FormData(uploadForm);
+      try {
+        const response = await fetch('upload.php', { method: 'POST', body: formData });
+        const text = await response.text();
+        document.getElementById('message').textContent = text;
+        uploadForm.reset();
+      } catch (err) {
+        document.getElementById('message').textContent = 'Błąd podczas przesyłania pliku';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/edc_site/upload.php
+++ b/edc_site/upload.php
@@ -1,0 +1,94 @@
+<?php
+// Simple upload handler for banner images
+// Protect with hashed password (sha256('edc_admin'))
+
+const PASSWORD_HASH = '37ba3d76293846ac3d3314714ef3a4438450b9c5ff48ab0c0252af9e2efe5285';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    exit('Metoda niedozwolona');
+}
+
+if (!isset($_POST['password']) || $_POST['password'] !== PASSWORD_HASH) {
+    http_response_code(401);
+    exit('Błędne hasło');
+}
+
+if (!isset($_FILES['banner']) || $_FILES['banner']['error'] !== UPLOAD_ERR_OK) {
+    http_response_code(400);
+    exit('Nieprawidłowy plik');
+}
+
+$allowed = ['jpg','jpeg','png','gif'];
+$ext = strtolower(pathinfo($_FILES['banner']['name'], PATHINFO_EXTENSION));
+if (!in_array($ext, $allowed)) {
+    http_response_code(400);
+    exit('Niedozwolony format pliku');
+}
+
+$targetDir = __DIR__ . '/images/banner/';
+$filename = basename($_FILES['banner']['name']);
+$filename = preg_replace('/[^A-Za-z0-9_.-]/', '_', $filename);
+$targetPath = $targetDir . $filename;
+
+if (!move_uploaded_file($_FILES['banner']['tmp_name'], $targetPath)) {
+    http_response_code(500);
+    exit('Nie udało się zapisać pliku');
+}
+
+list($width, $height) = getimagesize($targetPath);
+if ($width > 1600) {
+    $ratio = 1600 / $width;
+    $newWidth = 1600;
+    $newHeight = (int)($height * $ratio);
+
+    switch ($ext) {
+        case 'jpg':
+        case 'jpeg':
+            $src = imagecreatefromjpeg($targetPath);
+            break;
+        case 'png':
+            $src = imagecreatefrompng($targetPath);
+            break;
+        case 'gif':
+            $src = imagecreatefromgif($targetPath);
+            break;
+    }
+
+    $dst = imagecreatetruecolor($newWidth, $newHeight);
+    imagecopyresampled($dst, $src, 0, 0, 0, 0, $newWidth, $newHeight, $width, $height);
+
+    switch ($ext) {
+        case 'jpg':
+        case 'jpeg':
+            imagejpeg($dst, $targetPath, 90);
+            break;
+        case 'png':
+            imagepng($dst, $targetPath);
+            break;
+        case 'gif':
+            imagegif($dst, $targetPath);
+            break;
+    }
+
+    imagedestroy($src);
+    imagedestroy($dst);
+}
+
+$jsonPath = $targetDir . 'banner-images.json';
+$data = [];
+if (file_exists($jsonPath)) {
+    $content = file_get_contents($jsonPath);
+    $data = json_decode($content, true);
+    if (!is_array($data)) {
+        $data = [];
+    }
+}
+
+if (!in_array($filename, $data)) {
+    $data[] = $filename;
+    file_put_contents($jsonPath, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+}
+
+echo 'Plik przesłany pomyślnie';
+?>


### PR DESCRIPTION
## Summary
- create password-protected `update.html` admin page
- add PHP handler that resizes banner uploads and updates list

## Testing
- `npx htmlhint edc_site/update.html`
- `php -l edc_site/upload.php`


------
https://chatgpt.com/codex/tasks/task_b_689dc15b848c83308f2bfba109ad2a35