### PR TITLE
Make navigation mobile-friendly and scale sponsor logos

### DIFF
--- a/edc_site/index.html
+++ b/edc_site/index.html
@@ -15,6 +15,7 @@
         <!-- Use a local copy of the EDC logo instead of hotlinking to the old site. -->
         <img src="images/edc_logo.jpeg" alt="European Dealer Council logo">
       </a>
+      <button class="nav-toggle" aria-label="Toggle navigation">&#9776;</button>
       <nav>
         <ul>
           <li><a href="#home">Home</a></li>
@@ -214,5 +215,6 @@
 </script>
 <script src="hero-banner.js"></script>
 <script src="slideshow.js"></script>
+<script src="navbar.js"></script>
 </body>
 </html>

--- a/edc_site/map.html
+++ b/edc_site/map.html
@@ -13,6 +13,7 @@
       <a href="index.html#home" class="logo">
         <img src="images/edc_logo.jpeg" alt="European Dealer Council logo">
       </a>
+      <button class="nav-toggle" aria-label="Toggle navigation">&#9776;</button>
       <nav>
         <ul>
           <li><a href="index.html#home">Home</a></li>
@@ -66,6 +67,7 @@
       }).addTo(map);
     });
   </script>
+  <script src="navbar.js"></script>
 </body>
 </html>
 

--- a/edc_site/navbar.js
+++ b/edc_site/navbar.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.querySelector('.nav-toggle');
+  const nav = document.querySelector('.navbar nav');
+  if (toggle && nav) {
+    toggle.addEventListener('click', () => {
+      nav.classList.toggle('open');
+    });
+  }
+});

--- a/edc_site/styles.css
+++ b/edc_site/styles.css
@@ -39,6 +39,16 @@ body {
 
 .logo img {
   height: 50px;
+  max-width: 100%;
+  width: auto;
+}
+
+.nav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 1.8rem;
+  cursor: pointer;
 }
 
 .navbar nav ul {
@@ -263,7 +273,10 @@ body {
 }
 
 .partners-grid img {
-  height: 80px;
+  height: auto;
+  max-height: 80px;
+  width: auto;
+  max-width: 100%;
   object-fit: contain;
   filter: grayscale(100%);
   transition: filter 0.3s ease;
@@ -332,4 +345,41 @@ footer a {
 .dealer-popup .leaflet-popup-content-wrapper {
   font-size: 1.2rem;
   padding: 15px;
+}
+
+@media (max-width: 768px) {
+  .navbar nav {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    width: 100%;
+    background: #ffffff;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  }
+
+  .navbar nav.open {
+    display: block;
+  }
+
+  .navbar nav ul {
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 0;
+  }
+
+  .nav-toggle {
+    display: block;
+  }
+
+  .partners-grid {
+    gap: 20px;
+  }
+
+  .partners-grid img {
+    flex: 1 1 calc(50% - 20px);
+    max-width: calc(50% - 20px);
+    width: calc(50% - 20px);
+  }
 }


### PR DESCRIPTION
## Summary
- Add hamburger toggle and JS to collapse navigation on small screens.
- Ensure header and sponsor logos scale within the viewport for mobile devices.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689e121783508330bb24c5de5f512d82