### PR TITLE
fix: adjust mobile logo scaling and menu spacing

### DIFF
--- a/edc_site/styles.css
+++ b/edc_site/styles.css
@@ -38,7 +38,8 @@ body {
 }
 
 .logo img {
-  height: 50px;
+  max-height: 50px;
+  height: auto;
   max-width: 100%;
   width: auto;
 }
@@ -348,6 +349,10 @@ footer a {
 }
 
 @media (max-width: 768px) {
+  .nav-container {
+    justify-content: flex-start;
+  }
+
   .navbar nav {
     display: none;
     position: absolute;
@@ -371,6 +376,7 @@ footer a {
 
   .nav-toggle {
     display: block;
+    margin-left: 10px;
   }
 
   .partners-grid {


### PR DESCRIPTION
## Summary
- preserve EDC logo proportions on mobile and limit its height
- align mobile navbar items to the left and add spacing beside burger icon

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689eea64db2c8330b61820fb1b663899