### PR TITLE
Add language selection dropdown with flags

### DIFF
--- a/edc_site/index.html
+++ b/edc_site/index.html
@@ -24,6 +24,21 @@
           <li><a href="#news">News</a></li>
           <li><a href="map.html">Map</a></li>
           <li><a href="#contact">Contact</a></li>
+          <li class="language-selector">
+            <select id="language-select" aria-label="Select language">
+              <option value="en">🇬🇧 English</option>
+              <option value="de">🇩🇪 Deutsch</option>
+              <option value="fr">🇫🇷 Français</option>
+              <option value="it">🇮🇹 Italiano</option>
+              <option value="pl">🇵🇱 Polski</option>
+              <option value="nl">🇳🇱 Nederlands</option>
+              <option value="es">🇪🇸 Español</option>
+              <option value="pt">🇵🇹 Português</option>
+              <option value="sv">🇸🇪 Svenska</option>
+              <option value="fi">🇫🇮 Suomi</option>
+              <option value="no">🇳🇴 Norsk</option>
+            </select>
+          </li>
         </ul>
       </nav>
     </div>

--- a/edc_site/map.html
+++ b/edc_site/map.html
@@ -22,6 +22,21 @@
           <li><a href="index.html#news">News</a></li>
           <li><a href="map.html">Map</a></li>
           <li><a href="index.html#contact">Contact</a></li>
+          <li class="language-selector">
+            <select id="language-select" aria-label="Select language">
+              <option value="en">🇬🇧 English</option>
+              <option value="de">🇩🇪 Deutsch</option>
+              <option value="fr">🇫🇷 Français</option>
+              <option value="it">🇮🇹 Italiano</option>
+              <option value="pl">🇵🇱 Polski</option>
+              <option value="nl">🇳🇱 Nederlands</option>
+              <option value="es">🇪🇸 Español</option>
+              <option value="pt">🇵🇹 Português</option>
+              <option value="sv">🇸🇪 Svenska</option>
+              <option value="fi">🇫🇮 Suomi</option>
+              <option value="no">🇳🇴 Norsk</option>
+            </select>
+          </li>
         </ul>
       </nav>
     </div>

--- a/edc_site/navbar.js
+++ b/edc_site/navbar.js
@@ -6,4 +6,19 @@ document.addEventListener('DOMContentLoaded', () => {
       nav.classList.toggle('open');
     });
   }
+
+  const langSelect = document.getElementById('language-select');
+  if (langSelect) {
+    const params = new URLSearchParams(window.location.search);
+    const currentLang = params.get('lang') || 'en';
+    langSelect.value = currentLang;
+    document.documentElement.lang = currentLang;
+
+    langSelect.addEventListener('change', (e) => {
+      const lang = e.target.value;
+      const url = new URL(window.location.href);
+      url.searchParams.set('lang', lang);
+      window.location.href = url.toString();
+    });
+  }
 });

--- a/edc_site/styles.css
+++ b/edc_site/styles.css
@@ -69,6 +69,14 @@ body {
   color: #007BFF;
 }
 
+.language-selector select {
+  padding: 4px;
+  font-size: 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background-color: #fff;
+}
+
 /* Hero Section */
 .hero {
   height: 90vh;


### PR DESCRIPTION
## Summary
- Add language selector with country flag icons to main navigation
- Style selector and update script to persist selection via URL parameter

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a0db7f9fd483309f535633dc7a278f