### PR TITLE
Improve map handling and harmonize static pages

### DIFF
--- a/edc_site/dataprotection.html
+++ b/edc_site/dataprotection.html
@@ -3,13 +3,68 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Data protection details for the European Dealer Council website.">
   <title>Data Protection - European Dealer Council</title>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <h1>Data Protection</h1>
-  <p>This page outlines our approach to data protection and privacy.</p>
-  <p>For further information, please contact <a href="mailto:info@dealercouncil.eu">info@dealercouncil.eu</a>.</p>
-  <p><a href="index.html">Return to the homepage</a></p>
+  <header class="navbar">
+    <div class="container nav-container">
+      <a href="index.html#home" class="logo">
+        <img src="images/edc_logo.jpeg" alt="European Dealer Council logo">
+      </a>
+      <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">&#9776;</button>
+      <nav>
+        <ul>
+            <li><a href="index.html#home" data-i18n="nav.home">Home</a></li>
+            <li><a href="index.html#mission" data-i18n="nav.mission">Mission</a></li>
+            <li><a href="index.html#presidium" data-i18n="nav.presidium">Presidium</a></li>
+            <li><a href="index.html#news" data-i18n="nav.news">News</a></li>
+            <li><a href="map.html" data-i18n="nav.map">Map</a></li>
+            <li><a href="index.html#contact" data-i18n="nav.contact">Contact</a></li>
+          <li class="language-selector">
+            <select id="language-select" aria-label="Select language">
+              <option value="en">🇬🇧 English</option>
+              <option value="de">🇩🇪 Deutsch</option>
+              <option value="fr">🇫🇷 Français</option>
+              <option value="it">🇮🇹 Italiano</option>
+              <option value="pl">🇵🇱 Polski</option>
+              <option value="nl">🇳🇱 Nederlands</option>
+              <option value="es">🇪🇸 Español</option>
+              <option value="pt">🇵🇹 Português</option>
+              <option value="sv">🇸🇪 Svenska</option>
+              <option value="fi">🇫🇮 Suomi</option>
+              <option value="no">🇳🇴 Norsk</option>
+            </select>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container content-page">
+    <h1>Data Protection</h1>
+    <p>This page outlines our approach to data protection and privacy for visitors, members, and partners of the European Dealer Council.</p>
+    <p>We collect only the data necessary to provide our services, store it securely, and never share it with third parties without explicit consent or legal obligation.</p>
+    <p>For further information or to request access to your data, please contact <a href="mailto:info@dealercouncil.eu">info@dealercouncil.eu</a>.</p>
+    <p><a href="index.html#home">Return to the homepage</a></p>
+  </main>
+
+  <footer id="contact">
+    <div class="container">
+        <p><strong>European Dealer Council Volkswagen Group e.V.</strong></p>
+        <p>Kollberg 9 | 30916 Isernhagen | Germany</p>
+        <p><span data-i18n="footer.phone">Phone</span>: <a href="tel:+4951368986635">+49 (0)5136 898 6635</a></p>
+        <p><span data-i18n="footer.email">Email</span>: <a href="mailto:info@dealercouncil.eu">info@dealercouncil.eu</a></p>
+        <ul class="footer-links">
+          <li><a href="dataprotection.html" data-i18n="footer.dataProtection">Data protection</a></li>
+          <li><a href="terms.html" data-i18n="footer.terms">Terms of use</a></li>
+          <li><a href="imprint.html" data-i18n="footer.imprint">Imprint</a></li>
+        </ul>
+    </div>
+  </footer>
+
+  <script src="translations.js"></script>
+  <script src="navbar.js"></script>
 </body>
 </html>

--- a/edc_site/imprint.html
+++ b/edc_site/imprint.html
@@ -3,17 +3,71 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Imprint for the European Dealer Council website.">
   <title>Imprint - European Dealer Council</title>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <h1>Imprint</h1>
-  <p>European Dealer Council Volkswagen Group e.V.<br>
-     Kollberg 9<br>
-     30916 Isernhagen<br>
-     Germany</p>
-  <p>Phone: +49 (0)5136 898 6635<br>
-     Email: <a href="mailto:info@dealercouncil.eu">info@dealercouncil.eu</a></p>
-  <p><a href="index.html">Return to the homepage</a></p>
+  <header class="navbar">
+    <div class="container nav-container">
+      <a href="index.html#home" class="logo">
+        <img src="images/edc_logo.jpeg" alt="European Dealer Council logo">
+      </a>
+      <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">&#9776;</button>
+      <nav>
+        <ul>
+            <li><a href="index.html#home" data-i18n="nav.home">Home</a></li>
+            <li><a href="index.html#mission" data-i18n="nav.mission">Mission</a></li>
+            <li><a href="index.html#presidium" data-i18n="nav.presidium">Presidium</a></li>
+            <li><a href="index.html#news" data-i18n="nav.news">News</a></li>
+            <li><a href="map.html" data-i18n="nav.map">Map</a></li>
+            <li><a href="index.html#contact" data-i18n="nav.contact">Contact</a></li>
+          <li class="language-selector">
+            <select id="language-select" aria-label="Select language">
+              <option value="en">🇬🇧 English</option>
+              <option value="de">🇩🇪 Deutsch</option>
+              <option value="fr">🇫🇷 Français</option>
+              <option value="it">🇮🇹 Italiano</option>
+              <option value="pl">🇵🇱 Polski</option>
+              <option value="nl">🇳🇱 Nederlands</option>
+              <option value="es">🇪🇸 Español</option>
+              <option value="pt">🇵🇹 Português</option>
+              <option value="sv">🇸🇪 Svenska</option>
+              <option value="fi">🇫🇮 Suomi</option>
+              <option value="no">🇳🇴 Norsk</option>
+            </select>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container content-page">
+    <h1>Imprint</h1>
+    <p><strong>European Dealer Council Volkswagen Group e.V.</strong><br>
+       Kollberg 9<br>
+       30916 Isernhagen<br>
+       Germany</p>
+    <p><span data-i18n="footer.phone">Phone</span>: +49 (0)5136 898 6635<br>
+       <span data-i18n="footer.email">Email</span>: <a href="mailto:info@dealercouncil.eu">info@dealercouncil.eu</a></p>
+    <p><a href="index.html#home">Return to the homepage</a></p>
+  </main>
+
+  <footer id="contact">
+    <div class="container">
+        <p><strong>European Dealer Council Volkswagen Group e.V.</strong></p>
+        <p>Kollberg 9 | 30916 Isernhagen | Germany</p>
+        <p><span data-i18n="footer.phone">Phone</span>: <a href="tel:+4951368986635">+49 (0)5136 898 6635</a></p>
+        <p><span data-i18n="footer.email">Email</span>: <a href="mailto:info@dealercouncil.eu">info@dealercouncil.eu</a></p>
+        <ul class="footer-links">
+          <li><a href="dataprotection.html" data-i18n="footer.dataProtection">Data protection</a></li>
+          <li><a href="terms.html" data-i18n="footer.terms">Terms of use</a></li>
+          <li><a href="imprint.html" data-i18n="footer.imprint">Imprint</a></li>
+        </ul>
+    </div>
+  </footer>
+
+  <script src="translations.js"></script>
+  <script src="navbar.js"></script>
 </body>
 </html>

--- a/edc_site/index.html
+++ b/edc_site/index.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title data-i18n="title.main">European Dealer Council</title>
+  <meta name="description" content="European Dealer Council – connecting Volkswagen and Audi dealers across Europe with news, leadership, and dealer resources.">
+  <title data-i18n="title.main">European Dealer Council</title>
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
 </head>
@@ -15,14 +16,14 @@
         <!-- Use a local copy of the EDC logo instead of hotlinking to the old site. -->
         <img src="images/edc_logo.jpeg" alt="European Dealer Council logo">
       </a>
-      <button class="nav-toggle" aria-label="Toggle navigation">&#9776;</button>
+      <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">&#9776;</button>
       <nav>
         <ul>
             <li><a href="#home" data-i18n="nav.home">Home</a></li>
             <li><a href="#mission" data-i18n="nav.mission">Mission</a></li>
             <li><a href="#presidium" data-i18n="nav.presidium">Presidium</a></li>
             <li><a href="#news" data-i18n="nav.news">News</a></li>
-            <li><a href="map.html" data-i18n="nav.map">Map</a></li>
+            <li><a href="#map-section" data-i18n="nav.map">Map</a></li>
             <li><a href="#contact" data-i18n="nav.contact">Contact</a></li>
           <li class="language-selector">
             <select id="language-select" aria-label="Select language">
@@ -165,6 +166,7 @@
   <section class="map-section" id="map-section">
       <h2 data-i18n="map.title">European Dealers of Audi and Volkswagen Brand</h2>
       <p class="map-instruction" data-i18n="map.instruction">Move cursor of your mouse over country main city</p>
+      <p id="map-status" class="map-status" aria-live="polite"></p>
     <div id="map"></div>
   </section>
 
@@ -195,39 +197,7 @@
   </footer>
 
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-<script>
-  const map = L.map('map').setView([54, 15], 4);
-
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    attribution: '&copy; OpenStreetMap contributors'
-  }).addTo(map);
-
-  Promise.all([
-    fetch('json/europe.geojson').then(r => r.json()),
-    fetch('json/dealers.json').then(r => r.json())
-  ]).then(([geoData, dealers]) => {
-    L.geoJSON(geoData, {
-      pointToLayer: function(feature, latlng) {
-        return L.circleMarker(latlng, {
-          radius: 5,
-          color: '#007BFF',
-          fillColor: '#007BFF',
-          fillOpacity: 0.8
-        });
-      },
-      onEachFeature: function(feature, layer) {
-        const iso = feature.properties.iso_a2;
-        const info = dealers[iso];
-        if (info) {
-          const content = `<strong>${info.country}</strong><br>Audi: ${info.audi}<br>VW: ${info.vw}`;
-          layer.bindPopup(content, { className: 'dealer-popup', maxWidth: 400 });
-          layer.on('mouseover', function() { this.openPopup(); });
-          layer.on('mouseout', function() { this.closePopup(); });
-        }
-      }
-    }).addTo(map);
-  });
-</script>
+<script src="map.js"></script>
   <script src="hero-banner.js"></script>
   <script src="slideshow.js"></script>
   <script src="translations.js"></script>

--- a/edc_site/map.html
+++ b/edc_site/map.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title data-i18n="title.map">Dealer Map - European Dealer Council</title>
+  <meta name="description" content="Dealer map of the European Dealer Council connecting Volkswagen and Audi partners across Europe.">
+  <title data-i18n="title.map">Dealer Map - European Dealer Council</title>
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
 </head>
@@ -13,7 +14,7 @@
       <a href="index.html#home" class="logo">
         <img src="images/edc_logo.jpeg" alt="European Dealer Council logo">
       </a>
-      <button class="nav-toggle" aria-label="Toggle navigation">&#9776;</button>
+      <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">&#9776;</button>
       <nav>
         <ul>
             <li><a href="index.html#home" data-i18n="nav.home">Home</a></li>
@@ -45,43 +46,12 @@
   <main class="map-section">
       <h1 data-i18n="map.title">European Dealers of Audi and Volkswagen Brand</h1>
       <p class="map-instruction" data-i18n="map.instruction">Move cursor of your mouse over country main city</p>
+      <p id="map-status" class="map-status" aria-live="polite"></p>
     <div id="map"></div>
   </main>
 
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-  <script>
-    const map = L.map('map').setView([54, 15], 4);
-
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      attribution: '&copy; OpenStreetMap contributors'
-    }).addTo(map);
-
-    Promise.all([
-      fetch('json/europe.geojson').then(r => r.json()),
-      fetch('json/dealers.json').then(r => r.json())
-    ]).then(([geoData, dealers]) => {
-      L.geoJSON(geoData, {
-        pointToLayer: function(feature, latlng) {
-          return L.circleMarker(latlng, {
-            radius: 5,
-            color: '#007BFF',
-            fillColor: '#007BFF',
-            fillOpacity: 0.8
-          });
-        },
-        onEachFeature: function(feature, layer) {
-          const iso = feature.properties.iso_a2;
-          const info = dealers[iso];
-          if (info) {
-            const content = `<strong>${info.country}</strong><br>Audi: ${info.audi}<br>VW: ${info.vw}`;
-            layer.bindPopup(content, { className: 'dealer-popup', maxWidth: 400 });
-            layer.on('mouseover', function() { this.openPopup(); });
-            layer.on('mouseout', function() { this.closePopup(); });
-          }
-        }
-      }).addTo(map);
-    });
-  </script>
+  <script src="map.js"></script>
   <script src="translations.js"></script>
   <script src="navbar.js"></script>
   </body>

--- a/edc_site/map.js
+++ b/edc_site/map.js
@@ -1,0 +1,50 @@
+// Initialize Leaflet map when a map container is present
+// Reusable across pages (homepage section and dedicated map page)
+document.addEventListener('DOMContentLoaded', () => {
+  const mapContainer = document.getElementById('map');
+  if (!mapContainer || typeof L === 'undefined') return;
+
+  const map = L.map(mapContainer).setView([54, 15], 4);
+
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; OpenStreetMap contributors'
+  }).addTo(map);
+
+  Promise.all([
+    fetch('json/europe.geojson').then((response) => response.json()),
+    fetch('json/dealers.json').then((response) => response.json())
+  ])
+    .then(([geoData, dealers]) => {
+      L.geoJSON(geoData, {
+        pointToLayer(feature, latlng) {
+          return L.circleMarker(latlng, {
+            radius: 5,
+            color: '#007BFF',
+            fillColor: '#007BFF',
+            fillOpacity: 0.8
+          });
+        },
+        onEachFeature(feature, layer) {
+          const iso = feature.properties.iso_a2;
+          const info = dealers[iso];
+          if (info) {
+            const content = `<strong>${info.country}</strong><br>Audi: ${info.audi}<br>VW: ${info.vw}`;
+            layer.bindPopup(content, { className: 'dealer-popup', maxWidth: 400 });
+            layer.on('mouseover', function handleMouseOver() {
+              this.openPopup();
+            });
+            layer.on('mouseout', function handleMouseOut() {
+              this.closePopup();
+            });
+          }
+        }
+      }).addTo(map);
+    })
+    .catch((error) => {
+      console.error('Failed to load dealer map data', error);
+      const status = document.getElementById('map-status');
+      if (status) {
+        status.textContent = 'We were unable to load the dealer map data. Please try again later.';
+      }
+    });
+});

--- a/edc_site/navbar.js
+++ b/edc_site/navbar.js
@@ -2,9 +2,25 @@ document.addEventListener('DOMContentLoaded', () => {
   const toggle = document.querySelector('.nav-toggle');
   const nav = document.querySelector('.navbar nav');
   if (toggle && nav) {
+    const updateExpanded = () => {
+      toggle.setAttribute('aria-expanded', nav.classList.contains('open'));
+    };
+
     toggle.addEventListener('click', () => {
       nav.classList.toggle('open');
+      updateExpanded();
     });
+
+    nav.querySelectorAll('a').forEach(link => {
+      link.addEventListener('click', () => {
+        if (nav.classList.contains('open')) {
+          nav.classList.remove('open');
+          updateExpanded();
+        }
+      });
+    });
+
+    updateExpanded();
   }
 
   const langSelect = document.getElementById('language-select');

--- a/edc_site/styles.css
+++ b/edc_site/styles.css
@@ -13,6 +13,26 @@ body {
   padding-top: 80px; /* space for fixed navbar */
 }
 
+main {
+  display: block;
+}
+
+.content-page {
+  padding: 40px 0 80px;
+}
+
+.content-page h1 {
+  color: #003366;
+  margin-bottom: 20px;
+  font-size: 2rem;
+}
+
+.content-page p {
+  margin-bottom: 16px;
+  font-size: 1rem;
+  color: #444;
+}
+
 .container {
   width: 90%;
   max-width: 1200px;
@@ -349,6 +369,13 @@ footer a {
   font-size: 1rem;
   color: #555;
   margin-bottom: 1rem;
+}
+
+.map-status {
+  font-size: 0.95rem;
+  color: #c0392b;
+  min-height: 1.2em;
+  margin-bottom: 0.75rem;
 }
 
 .dealer-popup .leaflet-popup-content-wrapper {

--- a/edc_site/terms.html
+++ b/edc_site/terms.html
@@ -3,13 +3,68 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Terms of use for the European Dealer Council website.">
   <title>Terms of Use - European Dealer Council</title>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <h1>Terms of Use</h1>
-  <p>These terms govern the use of the European Dealer Council website.</p>
-  <p>By accessing this site, you agree to comply with these terms and all applicable laws and regulations.</p>
-  <p><a href="index.html">Return to the homepage</a></p>
+  <header class="navbar">
+    <div class="container nav-container">
+      <a href="index.html#home" class="logo">
+        <img src="images/edc_logo.jpeg" alt="European Dealer Council logo">
+      </a>
+      <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">&#9776;</button>
+      <nav>
+        <ul>
+            <li><a href="index.html#home" data-i18n="nav.home">Home</a></li>
+            <li><a href="index.html#mission" data-i18n="nav.mission">Mission</a></li>
+            <li><a href="index.html#presidium" data-i18n="nav.presidium">Presidium</a></li>
+            <li><a href="index.html#news" data-i18n="nav.news">News</a></li>
+            <li><a href="map.html" data-i18n="nav.map">Map</a></li>
+            <li><a href="index.html#contact" data-i18n="nav.contact">Contact</a></li>
+          <li class="language-selector">
+            <select id="language-select" aria-label="Select language">
+              <option value="en">🇬🇧 English</option>
+              <option value="de">🇩🇪 Deutsch</option>
+              <option value="fr">🇫🇷 Français</option>
+              <option value="it">🇮🇹 Italiano</option>
+              <option value="pl">🇵🇱 Polski</option>
+              <option value="nl">🇳🇱 Nederlands</option>
+              <option value="es">🇪🇸 Español</option>
+              <option value="pt">🇵🇹 Português</option>
+              <option value="sv">🇸🇪 Svenska</option>
+              <option value="fi">🇫🇮 Suomi</option>
+              <option value="no">🇳🇴 Norsk</option>
+            </select>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container content-page">
+    <h1>Terms of Use</h1>
+    <p>These terms govern the use of the European Dealer Council website. By accessing this site, you agree to comply with these terms and all applicable laws and regulations.</p>
+    <p>Content on this website is provided for information purposes. We strive to keep information current, but we do not accept liability for any inaccuracies.</p>
+    <p>If you have questions about these terms, please contact <a href="mailto:info@dealercouncil.eu">info@dealercouncil.eu</a>.</p>
+    <p><a href="index.html#home">Return to the homepage</a></p>
+  </main>
+
+  <footer id="contact">
+    <div class="container">
+        <p><strong>European Dealer Council Volkswagen Group e.V.</strong></p>
+        <p>Kollberg 9 | 30916 Isernhagen | Germany</p>
+        <p><span data-i18n="footer.phone">Phone</span>: <a href="tel:+4951368986635">+49 (0)5136 898 6635</a></p>
+        <p><span data-i18n="footer.email">Email</span>: <a href="mailto:info@dealercouncil.eu">info@dealercouncil.eu</a></p>
+        <ul class="footer-links">
+          <li><a href="dataprotection.html" data-i18n="footer.dataProtection">Data protection</a></li>
+          <li><a href="terms.html" data-i18n="footer.terms">Terms of use</a></li>
+          <li><a href="imprint.html" data-i18n="footer.imprint">Imprint</a></li>
+        </ul>
+    </div>
+  </footer>
+
+  <script src="translations.js"></script>
+  <script src="navbar.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add reusable Leaflet map script with user feedback and status messaging
- update navigation for better accessibility and hero/map metadata improvements
- restyle legal pages to match the main site layout with consistent header and footer

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69216437b3848330b8e465771cc28b91)