### PR TITLE
Add CMS page for managing site content and media

### DIFF
--- a/edc_site/cms-save.php
+++ b/edc_site/cms-save.php
@@ -8,14 +8,20 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     exit('Metoda niedozwolona');
 }
 
+$lang = $_POST['lang'] ?? 'pl';
+
+function t(string $pl, string $en, string $lang): string {
+    return $lang === 'en' ? $en : $pl;
+}
+
 if (!isset($_POST['password']) || $_POST['password'] !== PASSWORD_HASH) {
     http_response_code(401);
-    exit('Błędne hasło');
+    exit(t('Błędne hasło', 'Incorrect password', $lang));
 }
 
 if (!is_dir(UPLOAD_DIR) && !mkdir(UPLOAD_DIR, 0775, true)) {
     http_response_code(500);
-    exit('Nie udało się przygotować katalogu na pliki.');
+    exit(t('Nie udało się przygotować katalogu na pliki.', 'Could not prepare upload directory.', $lang));
 }
 
 function loadContent(): array {
@@ -37,21 +43,21 @@ function saveContent(array $data): void {
     file_put_contents(CONTENT_PATH, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES), LOCK_EX);
 }
 
-function storeImage(array $file): ?string {
+function storeImage(array $file, string $lang): ?string {
     if (!isset($file['error']) || $file['error'] === UPLOAD_ERR_NO_FILE) {
         return null;
     }
 
     if ($file['error'] !== UPLOAD_ERR_OK) {
         http_response_code(400);
-        exit('Błąd podczas przesyłania pliku.');
+        exit(t('Błąd podczas przesyłania pliku.', 'Error while uploading file.', $lang));
     }
 
     $allowed = ['jpg', 'jpeg', 'png', 'gif'];
     $ext = strtolower(pathinfo($file['name'], PATHINFO_EXTENSION));
     if (!in_array($ext, $allowed)) {
         http_response_code(400);
-        exit('Niedozwolony format pliku.');
+        exit(t('Niedozwolony format pliku.', 'Unsupported file type.', $lang));
     }
 
     $filename = uniqid('upload_', true) . '.' . $ext;
@@ -59,7 +65,7 @@ function storeImage(array $file): ?string {
 
     if (!move_uploaded_file($file['tmp_name'], $targetPath)) {
         http_response_code(500);
-        exit('Nie udało się zapisać pliku.');
+        exit(t('Nie udało się zapisać pliku.', 'Failed to save file.', $lang));
     }
 
     $info = getimagesize($targetPath);
@@ -118,7 +124,7 @@ if ($action === 'updateHero') {
 
     if ($title === '' || $subtitle === '') {
         http_response_code(400);
-        exit('Uzupełnij tytuł i podtytuł.');
+        exit(t('Uzupełnij tytuł i podtytuł.', 'Please fill in title and subtitle.', $lang));
     }
 
     $content['hero'] = [
@@ -127,7 +133,7 @@ if ($action === 'updateHero') {
     ];
 
     saveContent($content);
-    exit('Nagłówek został zaktualizowany.');
+    exit(t('Nagłówek został zaktualizowany.', 'Hero content updated.', $lang));
 }
 
 if ($action === 'addNews') {
@@ -138,7 +144,7 @@ if ($action === 'addNews') {
 
     if ($title === '' || $date === '' || $alt === '') {
         http_response_code(400);
-        exit('Tytuł, data i tekst alternatywny są wymagane.');
+        exit(t('Tytuł, data i tekst alternatywny są wymagane.', 'Title, date and alternative text are required.', $lang));
     }
 
     $newsItem = [
@@ -151,7 +157,7 @@ if ($action === 'addNews') {
     ];
 
     if (isset($_FILES['mainImage'])) {
-        $path = storeImage($_FILES['mainImage']);
+        $path = storeImage($_FILES['mainImage'], $lang);
         if ($path) {
             $newsItem['image'] = $path;
             $newsItem['gallery'][] = $path;
@@ -167,7 +173,7 @@ if ($action === 'addNews') {
                 'error' => $_FILES['gallery']['error'][$index],
                 'size' => $_FILES['gallery']['size'][$index],
             ];
-            $path = storeImage($file);
+            $path = storeImage($file, $lang);
             if ($path) {
                 $newsItem['gallery'][] = $path;
             }
@@ -176,17 +182,15 @@ if ($action === 'addNews') {
 
     if (!$newsItem['image']) {
         http_response_code(400);
-        exit('Dodaj główną grafikę dla aktualności.');
+        exit(t('Dodaj główną grafikę dla aktualności.', 'Add a main image for the news item.', $lang));
     }
 
-    // Ensure gallery is unique and keeps insertion order
     $newsItem['gallery'] = array_values(array_unique($newsItem['gallery']));
 
     array_unshift($content['news'], $newsItem);
     saveContent($content);
-    exit('Aktualność została dodana.');
+    exit(t('Aktualność została dodana.', 'News item added.', $lang));
 }
 
 http_response_code(400);
-exit('Nieznana akcja.');
-
+exit(t('Nieznana akcja.', 'Unknown action.', $lang));

--- a/edc_site/cms-save.php
+++ b/edc_site/cms-save.php
@@ -1,0 +1,192 @@
+<?php
+const PASSWORD_HASH = '37ba3d76293846ac3d3314714ef3a4438450b9c5ff48ab0c0252af9e2efe5285';
+const CONTENT_PATH = __DIR__ . '/json/content.json';
+const UPLOAD_DIR = __DIR__ . '/images/uploads/';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    exit('Metoda niedozwolona');
+}
+
+if (!isset($_POST['password']) || $_POST['password'] !== PASSWORD_HASH) {
+    http_response_code(401);
+    exit('Błędne hasło');
+}
+
+if (!is_dir(UPLOAD_DIR) && !mkdir(UPLOAD_DIR, 0775, true)) {
+    http_response_code(500);
+    exit('Nie udało się przygotować katalogu na pliki.');
+}
+
+function loadContent(): array {
+    if (!file_exists(CONTENT_PATH)) {
+        return ['hero' => [], 'news' => []];
+    }
+    $json = file_get_contents(CONTENT_PATH);
+    $data = json_decode($json, true);
+    if (!is_array($data)) {
+        return ['hero' => [], 'news' => []];
+    }
+    if (!isset($data['news']) || !is_array($data['news'])) {
+        $data['news'] = [];
+    }
+    return $data;
+}
+
+function saveContent(array $data): void {
+    file_put_contents(CONTENT_PATH, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES), LOCK_EX);
+}
+
+function storeImage(array $file): ?string {
+    if (!isset($file['error']) || $file['error'] === UPLOAD_ERR_NO_FILE) {
+        return null;
+    }
+
+    if ($file['error'] !== UPLOAD_ERR_OK) {
+        http_response_code(400);
+        exit('Błąd podczas przesyłania pliku.');
+    }
+
+    $allowed = ['jpg', 'jpeg', 'png', 'gif'];
+    $ext = strtolower(pathinfo($file['name'], PATHINFO_EXTENSION));
+    if (!in_array($ext, $allowed)) {
+        http_response_code(400);
+        exit('Niedozwolony format pliku.');
+    }
+
+    $filename = uniqid('upload_', true) . '.' . $ext;
+    $targetPath = UPLOAD_DIR . $filename;
+
+    if (!move_uploaded_file($file['tmp_name'], $targetPath)) {
+        http_response_code(500);
+        exit('Nie udało się zapisać pliku.');
+    }
+
+    $info = getimagesize($targetPath);
+    if ($info && $info[0] > 1600) {
+        [$width, $height] = $info;
+        $ratio = 1600 / $width;
+        $newWidth = 1600;
+        $newHeight = (int)($height * $ratio);
+
+        switch ($ext) {
+            case 'jpg':
+            case 'jpeg':
+                $src = imagecreatefromjpeg($targetPath);
+                break;
+            case 'png':
+                $src = imagecreatefrompng($targetPath);
+                break;
+            case 'gif':
+                $src = imagecreatefromgif($targetPath);
+                break;
+            default:
+                $src = null;
+        }
+
+        if ($src) {
+            $dst = imagecreatetruecolor($newWidth, $newHeight);
+            imagecopyresampled($dst, $src, 0, 0, 0, 0, $newWidth, $newHeight, $width, $height);
+
+            switch ($ext) {
+                case 'jpg':
+                case 'jpeg':
+                    imagejpeg($dst, $targetPath, 90);
+                    break;
+                case 'png':
+                    imagepng($dst, $targetPath);
+                    break;
+                case 'gif':
+                    imagegif($dst, $targetPath);
+                    break;
+            }
+
+            imagedestroy($src);
+            imagedestroy($dst);
+        }
+    }
+
+    return 'images/uploads/' . $filename;
+}
+
+$action = $_POST['action'] ?? '';
+$content = loadContent();
+
+if ($action === 'updateHero') {
+    $title = trim($_POST['heroTitle'] ?? '');
+    $subtitle = trim($_POST['heroSubtitle'] ?? '');
+
+    if ($title === '' || $subtitle === '') {
+        http_response_code(400);
+        exit('Uzupełnij tytuł i podtytuł.');
+    }
+
+    $content['hero'] = [
+        'title' => $title,
+        'subtitle' => $subtitle,
+    ];
+
+    saveContent($content);
+    exit('Nagłówek został zaktualizowany.');
+}
+
+if ($action === 'addNews') {
+    $title = trim($_POST['title'] ?? '');
+    $date = trim($_POST['date'] ?? '');
+    $summary = trim($_POST['summary'] ?? '');
+    $alt = trim($_POST['alt'] ?? '');
+
+    if ($title === '' || $date === '' || $alt === '') {
+        http_response_code(400);
+        exit('Tytuł, data i tekst alternatywny są wymagane.');
+    }
+
+    $newsItem = [
+        'title' => $title,
+        'date' => $date,
+        'summary' => $summary,
+        'alt' => $alt,
+        'image' => null,
+        'gallery' => [],
+    ];
+
+    if (isset($_FILES['mainImage'])) {
+        $path = storeImage($_FILES['mainImage']);
+        if ($path) {
+            $newsItem['image'] = $path;
+            $newsItem['gallery'][] = $path;
+        }
+    }
+
+    if (isset($_FILES['gallery']) && is_array($_FILES['gallery']['name'])) {
+        foreach ($_FILES['gallery']['name'] as $index => $name) {
+            $file = [
+                'name' => $name,
+                'type' => $_FILES['gallery']['type'][$index],
+                'tmp_name' => $_FILES['gallery']['tmp_name'][$index],
+                'error' => $_FILES['gallery']['error'][$index],
+                'size' => $_FILES['gallery']['size'][$index],
+            ];
+            $path = storeImage($file);
+            if ($path) {
+                $newsItem['gallery'][] = $path;
+            }
+        }
+    }
+
+    if (!$newsItem['image']) {
+        http_response_code(400);
+        exit('Dodaj główną grafikę dla aktualności.');
+    }
+
+    // Ensure gallery is unique and keeps insertion order
+    $newsItem['gallery'] = array_values(array_unique($newsItem['gallery']));
+
+    array_unshift($content['news'], $newsItem);
+    saveContent($content);
+    exit('Aktualność została dodana.');
+}
+
+http_response_code(400);
+exit('Nieznana akcja.');
+

--- a/edc_site/cms.html
+++ b/edc_site/cms.html
@@ -115,8 +115,6 @@
   </div>
 
   <script>
-    const PASSWORD_HASH = '37ba3d76293846ac3d3314714ef3a4438450b9c5ff48ab0c0252af9e2efe5285'; // sha256('edc_admin')
-
     const translations = {
       pl: {
         title: 'Panel CMS',
@@ -173,11 +171,7 @@
     };
 
     let currentLang = 'pl';
-
-    async function sha256(str) {
-      const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(str));
-      return Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2, '0')).join('');
-    }
+    let currentPassword = '';
 
     function applyLanguage(lang) {
       const dict = translations[lang] || translations.pl;
@@ -237,18 +231,38 @@
 
     async function handleLogin(event) {
       event.preventDefault();
-      const password = document.getElementById('password').value;
-      const hash = await sha256(password);
-      if (hash !== PASSWORD_HASH) {
+      const password = document.getElementById('password').value.trim();
+      if (!password) {
         setStatus('hero-status', translations[currentLang].errors.wrongPassword, false);
         return;
       }
-      document.querySelectorAll('input[name="password"]').forEach(input => {
-        input.value = hash;
-      });
-      document.getElementById('login-panel').style.display = 'none';
-      document.getElementById('cms-panel').style.display = 'block';
-      fetchContent();
+
+      const formData = new FormData();
+      formData.append('password', password);
+      formData.append('lang', currentLang);
+      formData.append('action', 'validate');
+
+      try {
+        const response = await fetch('cms-save.php', {
+          method: 'POST',
+          body: formData
+        });
+        const text = await response.text();
+        if (!response.ok) {
+          setStatus('hero-status', text || translations[currentLang].errors.wrongPassword, false);
+          return;
+        }
+
+        currentPassword = password;
+        document.querySelectorAll('input[name="password"]').forEach(input => {
+          input.value = currentPassword;
+        });
+        document.getElementById('login-panel').style.display = 'none';
+        document.getElementById('cms-panel').style.display = 'block';
+        fetchContent();
+      } catch (err) {
+        setStatus('hero-status', translations[currentLang].errors.fetchFailed, false);
+      }
     }
 
     async function submitForm(formId, statusId) {
@@ -267,7 +281,7 @@
           if (ok && formId === 'news-form') {
             form.reset();
             document.querySelectorAll('input[name="password"]').forEach(input => {
-              input.value = PASSWORD_HASH;
+              input.value = currentPassword;
             });
             document.querySelectorAll('input[name="lang"]').forEach(input => input.value = currentLang);
             fetchContent();

--- a/edc_site/cms.html
+++ b/edc_site/cms.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Panel CMS</title>
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    body { background: #f5f5f5; }
+    .cms-container { max-width: 960px; margin: 2rem auto; background: #fff; padding: 2rem; border-radius: 8px; box-shadow: 0 4px 12px rgba(0,0,0,0.1); }
+    .cms-container h1 { margin-top: 0; }
+    .form-group { margin-bottom: 1rem; }
+    label { display: block; font-weight: 600; margin-bottom: 0.25rem; }
+    input[type="text"], input[type="password"], input[type="date"], textarea { width: 100%; padding: 0.5rem; border: 1px solid #ccc; border-radius: 4px; }
+    textarea { min-height: 100px; }
+    .form-actions { display: flex; gap: 1rem; align-items: center; }
+    .muted { color: #555; font-size: 0.9rem; }
+    .card { border: 1px solid #e0e0e0; border-radius: 6px; padding: 1rem; margin-bottom: 1.5rem; background: #fafafa; }
+    .status { margin-top: 0.5rem; font-weight: 600; }
+    .status.success { color: #0a7a25; }
+    .status.error { color: #b00020; }
+    .news-preview { list-style: disc; padding-left: 1.25rem; }
+  </style>
+</head>
+<body>
+  <div class="cms-container">
+    <h1>Panel CMS</h1>
+    <p>Zaloguj się, aby aktualizować treści strony i dodawać nowe grafiki.</p>
+
+    <div id="login-panel">
+      <div class="form-group">
+        <label for="password">Hasło administratora</label>
+        <input type="password" id="password" required>
+      </div>
+      <div class="form-actions">
+        <button id="login-button">Zaloguj</button>
+        <a href="mailto:michal@ignasza.pl?subject=Reset%20has%C5%82a" class="muted">Zapomniałem hasła</a>
+      </div>
+    </div>
+
+    <div id="cms-panel" style="display: none;">
+      <div class="card">
+        <h2>Nagłówek strony</h2>
+        <form id="hero-form">
+          <div class="form-group">
+            <label for="hero-title">Tytuł</label>
+            <input type="text" id="hero-title" name="heroTitle" required>
+          </div>
+          <div class="form-group">
+            <label for="hero-subtitle">Podtytuł</label>
+            <input type="text" id="hero-subtitle" name="heroSubtitle" required>
+          </div>
+          <input type="hidden" name="action" value="updateHero">
+          <input type="hidden" name="password">
+          <div class="form-actions">
+            <button type="submit">Zapisz nagłówek</button>
+            <span class="status" id="hero-status"></span>
+          </div>
+        </form>
+      </div>
+
+      <div class="card">
+        <h2>Dodaj aktualność</h2>
+        <form id="news-form" enctype="multipart/form-data">
+          <div class="form-group">
+            <label for="news-title">Tytuł</label>
+            <input type="text" id="news-title" name="title" required>
+          </div>
+          <div class="form-group">
+            <label for="news-date">Data</label>
+            <input type="date" id="news-date" name="date" required>
+          </div>
+          <div class="form-group">
+            <label for="news-summary">Opis (opcjonalny)</label>
+            <textarea id="news-summary" name="summary" placeholder="Krótki opis wydarzenia"></textarea>
+          </div>
+          <div class="form-group">
+            <label for="news-alt">Tekst alternatywny dla grafiki</label>
+            <input type="text" id="news-alt" name="alt" required>
+          </div>
+          <div class="form-group">
+            <label for="news-image">Główna grafika</label>
+            <input type="file" id="news-image" name="mainImage" accept="image/*" required>
+            <p class="muted">Plik zostanie zapisany w katalogu images/uploads.</p>
+          </div>
+          <div class="form-group">
+            <label for="news-gallery">Dodatkowe grafiki (opcjonalnie, wiele plików)</label>
+            <input type="file" id="news-gallery" name="gallery[]" accept="image/*" multiple>
+          </div>
+          <input type="hidden" name="action" value="addNews">
+          <input type="hidden" name="password">
+          <div class="form-actions">
+            <button type="submit">Dodaj aktualność</button>
+            <span class="status" id="news-status"></span>
+          </div>
+        </form>
+        <div class="form-group">
+          <label>Obecne aktualności</label>
+          <ul class="news-preview" id="news-preview"></ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const PASSWORD_HASH = '37ba3d76293846ac3d3314714ef3a4438450b9c5ff48ab0c0252af9e2efe5285'; // sha256('edc_admin')
+
+    async function sha256(str) {
+      const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(str));
+      return Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2, '0')).join('');
+    }
+
+    function setStatus(elementId, message, isSuccess = true) {
+      const el = document.getElementById(elementId);
+      if (!el) return;
+      el.textContent = message;
+      el.classList.toggle('success', isSuccess);
+      el.classList.toggle('error', !isSuccess);
+    }
+
+    async function fetchContent() {
+      try {
+        const response = await fetch('json/content.json', { cache: 'no-cache' });
+        if (!response.ok) return;
+        const data = await response.json();
+        document.getElementById('hero-title').value = data.hero?.title || '';
+        document.getElementById('hero-subtitle').value = data.hero?.subtitle || '';
+        const preview = document.getElementById('news-preview');
+        preview.innerHTML = '';
+        (data.news || []).forEach(item => {
+          const li = document.createElement('li');
+          const date = new Date(item.date).toLocaleDateString();
+          li.textContent = `${date} – ${item.title}`;
+          preview.appendChild(li);
+        });
+      } catch (err) {
+        setStatus('hero-status', 'Nie udało się pobrać danych', false);
+      }
+    }
+
+    async function handleLogin(event) {
+      event.preventDefault();
+      const password = document.getElementById('password').value;
+      const hash = await sha256(password);
+      if (hash !== PASSWORD_HASH) {
+        setStatus('hero-status', 'Błędne hasło', false);
+        return;
+      }
+      document.querySelectorAll('input[name="password"]').forEach(input => {
+        input.value = hash;
+      });
+      document.getElementById('login-panel').style.display = 'none';
+      document.getElementById('cms-panel').style.display = 'block';
+      fetchContent();
+    }
+
+    async function submitForm(formId, statusId) {
+      const form = document.getElementById(formId);
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const formData = new FormData(form);
+        try {
+          const response = await fetch('cms-save.php', {
+            method: 'POST',
+            body: formData
+          });
+          const text = await response.text();
+          const ok = response.ok;
+          setStatus(statusId, text, ok);
+          if (ok && formId === 'news-form') {
+            form.reset();
+            document.querySelectorAll('input[name="password"]').forEach(input => {
+              input.value = PASSWORD_HASH;
+            });
+            fetchContent();
+          }
+        } catch (err) {
+          setStatus(statusId, 'Nie udało się zapisać zmian', false);
+        }
+      });
+    }
+
+    document.getElementById('login-button').addEventListener('click', handleLogin);
+    submitForm('hero-form', 'hero-status');
+    submitForm('news-form', 'news-status');
+  </script>
+</body>
+</html>

--- a/edc_site/cms.html
+++ b/edc_site/cms.html
@@ -24,78 +24,90 @@
 </head>
 <body>
   <div class="cms-container">
-    <h1>Panel CMS</h1>
-    <p>Zaloguj się, aby aktualizować treści strony i dodawać nowe grafiki.</p>
+    <div class="form-actions" style="justify-content: space-between; align-items: center;">
+      <div>
+        <h1 id="cms-title">Panel CMS</h1>
+        <p id="cms-intro">Zaloguj się, aby aktualizować treści strony i dodawać nowe grafiki.</p>
+      </div>
+      <label class="muted" style="margin: 0;">Język:
+        <select id="language-select">
+          <option value="pl" selected>Polski</option>
+          <option value="en">English</option>
+        </select>
+      </label>
+    </div>
 
     <div id="login-panel">
       <div class="form-group">
-        <label for="password">Hasło administratora</label>
+        <label for="password" data-i18n="label.password">Hasło administratora</label>
         <input type="password" id="password" required>
       </div>
       <div class="form-actions">
-        <button id="login-button">Zaloguj</button>
-        <a href="mailto:michal@ignasza.pl?subject=Reset%20has%C5%82a" class="muted">Zapomniałem hasła</a>
+        <button id="login-button" data-i18n="action.login">Zaloguj</button>
+        <a id="forgot-password" href="mailto:michal@ignasza.pl?subject=Reset%20has%C5%82a" class="muted" data-i18n="link.forgot">Zapomniałem hasła</a>
       </div>
     </div>
 
     <div id="cms-panel" style="display: none;">
       <div class="card">
-        <h2>Nagłówek strony</h2>
+        <h2 data-i18n="section.hero">Nagłówek strony</h2>
         <form id="hero-form">
           <div class="form-group">
-            <label for="hero-title">Tytuł</label>
+            <label for="hero-title" data-i18n="label.title">Tytuł</label>
             <input type="text" id="hero-title" name="heroTitle" required>
           </div>
           <div class="form-group">
-            <label for="hero-subtitle">Podtytuł</label>
+            <label for="hero-subtitle" data-i18n="label.subtitle">Podtytuł</label>
             <input type="text" id="hero-subtitle" name="heroSubtitle" required>
           </div>
           <input type="hidden" name="action" value="updateHero">
           <input type="hidden" name="password">
+          <input type="hidden" name="lang" value="pl">
           <div class="form-actions">
-            <button type="submit">Zapisz nagłówek</button>
+            <button type="submit" data-i18n="action.saveHero">Zapisz nagłówek</button>
             <span class="status" id="hero-status"></span>
           </div>
         </form>
       </div>
 
       <div class="card">
-        <h2>Dodaj aktualność</h2>
+        <h2 data-i18n="section.news">Dodaj aktualność</h2>
         <form id="news-form" enctype="multipart/form-data">
           <div class="form-group">
-            <label for="news-title">Tytuł</label>
+            <label for="news-title" data-i18n="label.newsTitle">Tytuł</label>
             <input type="text" id="news-title" name="title" required>
           </div>
           <div class="form-group">
-            <label for="news-date">Data</label>
+            <label for="news-date" data-i18n="label.date">Data</label>
             <input type="date" id="news-date" name="date" required>
           </div>
           <div class="form-group">
-            <label for="news-summary">Opis (opcjonalny)</label>
+            <label for="news-summary" data-i18n="label.summary">Opis (opcjonalny)</label>
             <textarea id="news-summary" name="summary" placeholder="Krótki opis wydarzenia"></textarea>
           </div>
           <div class="form-group">
-            <label for="news-alt">Tekst alternatywny dla grafiki</label>
+            <label for="news-alt" data-i18n="label.alt">Tekst alternatywny dla grafiki</label>
             <input type="text" id="news-alt" name="alt" required>
           </div>
           <div class="form-group">
-            <label for="news-image">Główna grafika</label>
+            <label for="news-image" data-i18n="label.mainImage">Główna grafika</label>
             <input type="file" id="news-image" name="mainImage" accept="image/*" required>
-            <p class="muted">Plik zostanie zapisany w katalogu images/uploads.</p>
+            <p class="muted" id="upload-hint">Plik zostanie zapisany w katalogu images/uploads.</p>
           </div>
           <div class="form-group">
-            <label for="news-gallery">Dodatkowe grafiki (opcjonalnie, wiele plików)</label>
+            <label for="news-gallery" data-i18n="label.gallery">Dodatkowe grafiki (opcjonalnie, wiele plików)</label>
             <input type="file" id="news-gallery" name="gallery[]" accept="image/*" multiple>
           </div>
           <input type="hidden" name="action" value="addNews">
           <input type="hidden" name="password">
+          <input type="hidden" name="lang" value="pl">
           <div class="form-actions">
-            <button type="submit">Dodaj aktualność</button>
+            <button type="submit" data-i18n="action.addNews">Dodaj aktualność</button>
             <span class="status" id="news-status"></span>
           </div>
         </form>
         <div class="form-group">
-          <label>Obecne aktualności</label>
+          <label data-i18n="label.preview">Obecne aktualności</label>
           <ul class="news-preview" id="news-preview"></ul>
         </div>
       </div>
@@ -105,9 +117,94 @@
   <script>
     const PASSWORD_HASH = '37ba3d76293846ac3d3314714ef3a4438450b9c5ff48ab0c0252af9e2efe5285'; // sha256('edc_admin')
 
+    const translations = {
+      pl: {
+        title: 'Panel CMS',
+        intro: 'Zaloguj się, aby aktualizować treści strony i dodawać nowe grafiki.',
+        passwordLabel: 'Hasło administratora',
+        login: 'Zaloguj',
+        forgot: 'Zapomniałem hasła',
+        heroSection: 'Nagłówek strony',
+        newsSection: 'Dodaj aktualność',
+        titleLabel: 'Tytuł',
+        subtitleLabel: 'Podtytuł',
+        newsTitle: 'Tytuł',
+        date: 'Data',
+        summary: 'Opis (opcjonalny)',
+        alt: 'Tekst alternatywny dla grafiki',
+        mainImage: 'Główna grafika',
+        uploadHint: 'Plik zostanie zapisany w katalogu images/uploads.',
+        gallery: 'Dodatkowe grafiki (opcjonalnie, wiele plików)',
+        preview: 'Obecne aktualności',
+        saveHero: 'Zapisz nagłówek',
+        addNews: 'Dodaj aktualność',
+        errors: {
+          wrongPassword: 'Błędne hasło',
+          fetchFailed: 'Nie udało się pobrać danych',
+          saveFailed: 'Nie udało się zapisać zmian'
+        }
+      },
+      en: {
+        title: 'CMS Panel',
+        intro: 'Sign in to update site content and upload new media.',
+        passwordLabel: 'Administrator password',
+        login: 'Log in',
+        forgot: 'I forgot my password',
+        heroSection: 'Hero content',
+        newsSection: 'Add news item',
+        titleLabel: 'Title',
+        subtitleLabel: 'Subtitle',
+        newsTitle: 'Title',
+        date: 'Date',
+        summary: 'Summary (optional)',
+        alt: 'Alternative text for image',
+        mainImage: 'Main image',
+        uploadHint: 'File will be saved to images/uploads.',
+        gallery: 'Additional images (optional, multiple files)',
+        preview: 'Current news items',
+        saveHero: 'Save hero content',
+        addNews: 'Add news item',
+        errors: {
+          wrongPassword: 'Incorrect password',
+          fetchFailed: 'Unable to load data',
+          saveFailed: 'Unable to save changes'
+        }
+      }
+    };
+
+    let currentLang = 'pl';
+
     async function sha256(str) {
       const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(str));
       return Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2, '0')).join('');
+    }
+
+    function applyLanguage(lang) {
+      const dict = translations[lang] || translations.pl;
+      document.documentElement.lang = lang;
+      document.title = dict.title;
+      document.getElementById('cms-title').textContent = dict.title;
+      document.getElementById('cms-intro').textContent = dict.intro;
+      document.querySelector('label[for="password"]').textContent = dict.passwordLabel;
+      document.getElementById('login-button').textContent = dict.login;
+      document.getElementById('forgot-password').textContent = dict.forgot;
+      document.querySelector('[data-i18n="section.hero"]').textContent = dict.heroSection;
+      document.querySelector('[data-i18n="section.news"]').textContent = dict.newsSection;
+      document.querySelector('[for="hero-title"]').textContent = dict.titleLabel;
+      document.querySelector('[for="hero-subtitle"]').textContent = dict.subtitleLabel;
+      document.querySelector('[for="news-title"]').textContent = dict.newsTitle;
+      document.querySelector('[for="news-date"]').textContent = dict.date;
+      document.querySelector('[for="news-summary"]').textContent = dict.summary;
+      document.querySelector('[for="news-alt"]').textContent = dict.alt;
+      document.querySelector('[for="news-image"]').textContent = dict.mainImage;
+      document.getElementById('upload-hint').textContent = dict.uploadHint;
+      document.querySelector('[for="news-gallery"]').textContent = dict.gallery;
+      document.querySelector('[data-i18n="label.preview"]').textContent = dict.preview;
+      document.querySelector('[data-i18n="action.saveHero"]').textContent = dict.saveHero;
+      document.querySelector('[data-i18n="action.addNews"]').textContent = dict.addNews;
+
+      document.querySelectorAll('input[name="lang"]').forEach(input => input.value = lang);
+      currentLang = lang;
     }
 
     function setStatus(elementId, message, isSuccess = true) {
@@ -134,7 +231,7 @@
           preview.appendChild(li);
         });
       } catch (err) {
-        setStatus('hero-status', 'Nie udało się pobrać danych', false);
+        setStatus('hero-status', translations[currentLang].errors.fetchFailed, false);
       }
     }
 
@@ -143,7 +240,7 @@
       const password = document.getElementById('password').value;
       const hash = await sha256(password);
       if (hash !== PASSWORD_HASH) {
-        setStatus('hero-status', 'Błędne hasło', false);
+        setStatus('hero-status', translations[currentLang].errors.wrongPassword, false);
         return;
       }
       document.querySelectorAll('input[name="password"]').forEach(input => {
@@ -172,10 +269,11 @@
             document.querySelectorAll('input[name="password"]').forEach(input => {
               input.value = PASSWORD_HASH;
             });
+            document.querySelectorAll('input[name="lang"]').forEach(input => input.value = currentLang);
             fetchContent();
           }
         } catch (err) {
-          setStatus(statusId, 'Nie udało się zapisać zmian', false);
+          setStatus(statusId, translations[currentLang].errors.saveFailed, false);
         }
       });
     }
@@ -183,6 +281,12 @@
     document.getElementById('login-button').addEventListener('click', handleLogin);
     submitForm('hero-form', 'hero-status');
     submitForm('news-form', 'news-status');
+
+    document.getElementById('language-select').addEventListener('change', (event) => {
+      applyLanguage(event.target.value);
+    });
+
+    applyLanguage('pl');
   </script>
 </body>
 </html>

--- a/edc_site/index.html
+++ b/edc_site/index.html
@@ -130,34 +130,8 @@
   <section class="news" id="news">
     <div class="container">
         <h2 data-i18n="news.title">Latest News</h2>
-      <div class="news-grid">
-        <article class="news-item">
-          <div class="slideshow">
-            <img src="images/edc70/L1331163.jpg" alt="70th EUROPEAN DEALER COUNCIL Conference 2025 in Luxembourg">
-            <img src="images/edc70/L1331191.jpg" alt="70th EUROPEAN DEALER COUNCIL Conference 2025 in Luxembourg">
-            <img src="images/edc70/L1331292.jpg" alt="70th EUROPEAN DEALER COUNCIL Conference 2025 in Luxembourg">
-            <img src="images/edc70/L1331305.jpg" alt="70th EUROPEAN DEALER COUNCIL Conference 2025 in Luxembourg">
-            <img src="images/edc70/L1331545.jpg" alt="70th EUROPEAN DEALER COUNCIL Conference 2025 in Luxembourg">
-            <img src="images/edc70/L1331561.jpg" alt="70th EUROPEAN DEALER COUNCIL Conference 2025 in Luxembourg">
-            <img src="images/edc70/L1331797.jpg" alt="70th EUROPEAN DEALER COUNCIL Conference 2025 in Luxembourg">
-            <img src="images/edc70/L1331819.jpg" alt="70th EUROPEAN DEALER COUNCIL Conference 2025 in Luxembourg">
-            <img src="images/edc70/L1331877.jpg" alt="70th EUROPEAN DEALER COUNCIL Conference 2025 in Luxembourg">
-          </div>
-            <h3 data-i18n="news.article1.title">70th EUROPEAN DEALER COUNCIL Conference 2025 in Luxembourg</h3>
-            <time datetime="2025-05-01" data-i18n="news.article1.date">May 2025</time>
-        </article>
-        <article class="news-item">
-          <!-- Local copy of the conference image -->
-          <img src="images/ed_berlin_vorstand.jpeg" alt="69th EDC Conference in Berlin on December 11 and 12, 2024">
-            <h3 data-i18n="news.article2.title">69th EDC Conference in Berlin on December 11 and 12, 2024</h3>
-            <time datetime="2024-12-13" data-i18n="news.article2.date">13 December 2024</time>
-        </article>
-        <article class="news-item">
-          <!-- Local copy of the scaled conference image -->
-          <img src="images/edc_berlin_scaled.jpeg" alt="69th EDC Conference in Berlin">
-            <h3 data-i18n="news.article3.title">69th EDC Conference in Berlin</h3>
-            <time datetime="2024-12-11" data-i18n="news.article3.date">11 December 2024</time>
-        </article>
+      <div class="news-grid" id="news-grid">
+        <p class="news-placeholder">Loading the latest updates...</p>
       </div>
     </div>
   </section>
@@ -192,11 +166,13 @@
           <li><a href="dataprotection.html" data-i18n="footer.dataProtection">Data protection</a></li>
           <li><a href="terms.html" data-i18n="footer.terms">Terms of use</a></li>
           <li><a href="imprint.html" data-i18n="footer.imprint">Imprint</a></li>
+          <li><a href="cms.html">CMS</a></li>
         </ul>
     </div>
   </footer>
 
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<script src="cms-content.js"></script>
 <script src="map.js"></script>
   <script src="hero-banner.js"></script>
   <script src="slideshow.js"></script>

--- a/edc_site/json/content.json
+++ b/edc_site/json/content.json
@@ -1,0 +1,42 @@
+{
+  "hero": {
+    "title": "We connect European people and business",
+    "subtitle": "We bring European professionals together"
+  },
+  "news": [
+    {
+      "title": "70th EUROPEAN DEALER COUNCIL Conference 2025 in Luxembourg",
+      "date": "2025-05-01",
+      "image": "images/edc70/L1331163.jpg",
+      "gallery": [
+        "images/edc70/L1331163.jpg",
+        "images/edc70/L1331191.jpg",
+        "images/edc70/L1331292.jpg",
+        "images/edc70/L1331305.jpg",
+        "images/edc70/L1331545.jpg",
+        "images/edc70/L1331561.jpg",
+        "images/edc70/L1331797.jpg",
+        "images/edc70/L1331819.jpg",
+        "images/edc70/L1331877.jpg"
+      ],
+      "alt": "70th EUROPEAN DEALER COUNCIL Conference 2025 in Luxembourg",
+      "summary": "Highlights from the Luxembourg conference with rotating gallery imagery."
+    },
+    {
+      "title": "69th EDC Conference in Berlin on December 11 and 12, 2024",
+      "date": "2024-12-13",
+      "image": "images/ed_berlin_vorstand.jpeg",
+      "gallery": [],
+      "alt": "69th EDC Conference in Berlin on December 11 and 12, 2024",
+      "summary": "Delegates met in Berlin to discuss the future of the dealer network."
+    },
+    {
+      "title": "69th EDC Conference in Berlin",
+      "date": "2024-12-11",
+      "image": "images/edc_berlin_scaled.jpeg",
+      "gallery": [],
+      "alt": "69th EDC Conference in Berlin",
+      "summary": "Key outcomes from the Berlin meetings across the dealer community."
+    }
+  ]
+}

--- a/edc_site/slideshow.js
+++ b/edc_site/slideshow.js
@@ -1,13 +1,19 @@
-document.addEventListener('DOMContentLoaded', () => {
+function startSlideshows() {
   document.querySelectorAll('.slideshow').forEach(container => {
+    if (container.dataset.slideshowInit === 'true') return;
+
     const images = container.querySelectorAll('img');
     let index = 0;
     if (images.length === 0) return;
     images[index].classList.add('active');
+    container.dataset.slideshowInit = 'true';
     setInterval(() => {
       images[index].classList.remove('active');
       index = (index + 1) % images.length;
       images[index].classList.add('active');
     }, 3000);
   });
-});
+}
+
+document.addEventListener('DOMContentLoaded', startSlideshows);
+document.addEventListener('slideshows:refresh', startSlideshows);

--- a/edc_site/styles.css
+++ b/edc_site/styles.css
@@ -243,6 +243,11 @@ main {
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
 }
 
+.news-placeholder {
+  text-align: center;
+  color: #555;
+}
+
 .news-item {
   background: #ffffff;
   border-radius: 8px;
@@ -285,6 +290,12 @@ main {
   padding: 0 20px 15px;
   color: #777;
   font-size: 0.9rem;
+}
+
+.news-item p {
+  padding: 0 20px 20px;
+  color: #333;
+  line-height: 1.5;
 }
 
 /* Partners */


### PR DESCRIPTION
## Summary
- add a password-protected CMS page that lets editors update hero text and submit new news entries with images
- store site copy and news metadata in a JSON file and load it dynamically on the homepage
- enable media uploads through a PHP handler and update slideshows to work with dynamically added content

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692337e8382483309d55d8130182d9ce)