### PR TITLE
Add default CMS fallback password

### DIFF
--- a/edc_site/cms-save.php
+++ b/edc_site/cms-save.php
@@ -1,6 +1,7 @@
 <?php
 const CONTENT_PATH = __DIR__ . '/json/content.json';
 const UPLOAD_DIR = __DIR__ . '/images/uploads/';
+const DEFAULT_PASSWORD = 'edc_admin';
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     http_response_code(405);
@@ -24,8 +25,7 @@ function configuredPasswordHash(string $lang): string {
         return hash('sha256', $plain);
     }
 
-    http_response_code(500);
-    exit(t('Hasło CMS nie zostało skonfigurowane na serwerze.', 'CMS password is not configured on the server.', $lang));
+    return hash('sha256', DEFAULT_PASSWORD);
 }
 
 $passwordHash = configuredPasswordHash($lang);


### PR DESCRIPTION
## Summary
- add a default CMS password fallback so the admin panel accepts "edc_admin" when no environment variables are configured

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69234695c4cc8330b02de6fcaeb95174)