### PR TITLE
Fix blob media requests missing auth context

### DIFF
--- a/edc_site/cms.html
+++ b/edc_site/cms.html
@@ -1122,6 +1122,8 @@
       const formData = new FormData();
       formData.append('action', 'listMedia');
       formData.append('password', currentPassword);
+      formData.append('username', currentUsername);
+      formData.append('lang', currentLang);
 
       try {
         const res = await fetch('api/cms-save.php', { method: 'POST', body: formData });
@@ -1202,6 +1204,7 @@
       formData.append('action', 'deleteMedia');
       formData.append('url', url);
       formData.append('password', currentPassword);
+      formData.append('username', currentUsername);
       formData.append('lang', currentLang);
 
       try {


### PR DESCRIPTION
## Summary
- include username and language when listing media from the CMS
- send full authentication context when deleting blob media files

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693ec8e3fda483309faf712b410ce3c7)