### PR TITLE
Handle 2xx responses from Vercel Blob upload

### DIFF
--- a/edc_site/api/cms-save.php
+++ b/edc_site/api/cms-save.php
@@ -34,7 +34,8 @@ function vercelBlobPut(array $file): ?string
     $postCode = curl_getinfo($postCh, CURLINFO_HTTP_CODE);
     curl_close($postCh);
 
-    if ($postCode === 200) {
+    // Vercel Blob may return 200 or 201 on success depending on API version
+    if ($postCode >= 200 && $postCode < 300) {
         $json = json_decode($postResponse, true);
         if (isset($json['url'])) {
             return $json['url'];


### PR DESCRIPTION
## Summary
- accept any successful 2xx status when uploading to Vercel Blob
- preserve existing fallback logic if upload still fails

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693f087c4c408330b78a45977c89497b)