### PR TITLE
Adjust mobile hero and partner sizing

### DIFF
--- a/edc_site/styles.css
+++ b/edc_site/styles.css
@@ -575,18 +575,45 @@ footer a:hover {
     --section-padding: 60px 0;
   }
 
+  body {
+    font-size: 15px;
+    line-height: 1.6;
+  }
+
   .navbar nav {
     background: var(--white);
     padding: 20px;
     border-bottom: 1px solid rgba(0, 0, 0, 0.1);
   }
 
+  h2 {
+    font-size: 2rem;
+  }
+
+  .lead {
+    font-size: 1.05rem;
+    margin-bottom: 40px;
+  }
+
+  .hero {
+    height: 65vh;
+    min-height: 360px;
+    background-size: cover;
+    background-position: center;
+  }
+
+  .hero-overlay {
+    padding: 32px 28px;
+    max-width: 90%;
+  }
+
   .hero h1 {
-    font-size: 2.5rem;
+    font-size: 2rem;
+    line-height: 1.15;
   }
 
   .hero p {
-    font-size: 1.1rem;
+    font-size: 1rem;
   }
 
   .nav-container {
@@ -610,5 +637,13 @@ footer a:hover {
     flex-direction: column;
     align-items: center;
     gap: 20px;
+  }
+
+  .partners-grid {
+    gap: 32px;
+  }
+
+  .partners-grid img {
+    height: 40px;
   }
 }


### PR DESCRIPTION
## Summary
- reduce mobile typography sizing to improve readability and layout
- resize hero section on mobile for better viewport fit while keeping image coverage
- shrink partner logo sizes and spacing on small screens

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693f0b9dcc4c8330b80f908c8fa979bd)