### PR TITLE
Add responsive `chinatrip26` subpage with live China-time schedule tracking

### DIFF
--- a/edc_site/chinatrip26.html
+++ b/edc_site/chinatrip26.html
@@ -1,0 +1,381 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>China Trip 2026 | Harmonogram</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f5f7fb;
+      --card: #ffffff;
+      --text: #182033;
+      --muted: #5c667a;
+      --line: #d9dfeb;
+      --accent: #0c63e7;
+      --accent-soft: #eaf2ff;
+      --current: #0f9d58;
+      --next: #f29900;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+      color: var(--text);
+      background: linear-gradient(180deg, #f8faff 0%, #f3f5fa 100%);
+      line-height: 1.45;
+    }
+
+    .container {
+      width: min(1060px, 100% - 2rem);
+      margin: 0 auto;
+      padding: 1rem 0 3rem;
+    }
+
+    .hero, .card {
+      background: var(--card);
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      box-shadow: 0 6px 20px rgba(19, 36, 77, 0.05);
+    }
+
+    .hero {
+      padding: 1.2rem;
+      margin-bottom: 1rem;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(1.2rem, 2.6vw, 1.8rem);
+    }
+
+    .sub {
+      margin: 0.35rem 0 0;
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+
+    .status-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 0.8rem;
+      margin-bottom: 1rem;
+    }
+
+    .card {
+      padding: 1rem;
+    }
+
+    .card h2 {
+      margin: 0 0 0.55rem;
+      font-size: 1rem;
+    }
+
+    .badge {
+      display: inline-block;
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.02em;
+      text-transform: uppercase;
+      border-radius: 999px;
+      padding: 0.2rem 0.55rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .b-current { background: #eaf9f0; color: var(--current); }
+    .b-next { background: #fff6e6; color: #9a6200; }
+
+    .tiny { color: var(--muted); font-size: 0.88rem; }
+
+    .timeline {
+      display: grid;
+      gap: 0.85rem;
+    }
+
+    .day {
+      background: var(--card);
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      overflow: hidden;
+    }
+
+    .day-head {
+      padding: 0.8rem 1rem;
+      background: #f4f8ff;
+      border-bottom: 1px solid var(--line);
+      font-weight: 700;
+    }
+
+    .items { padding: 0.25rem 0; }
+
+    .item {
+      display: grid;
+      grid-template-columns: 130px 1fr;
+      gap: 0.8rem;
+      padding: 0.7rem 1rem;
+      border-bottom: 1px solid #eef1f6;
+    }
+
+    .item:last-child { border-bottom: 0; }
+
+    .time {
+      font-weight: 700;
+      color: #0d3f95;
+      font-size: 0.92rem;
+    }
+
+    .title {
+      font-weight: 700;
+      margin-bottom: 0.15rem;
+    }
+
+    .desc {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.9rem;
+      white-space: pre-line;
+    }
+
+    .current-item {
+      background: #edfff4;
+      border-left: 3px solid var(--current);
+    }
+
+    .next-item {
+      background: #fff8eb;
+      border-left: 3px solid var(--next);
+    }
+
+    @media (max-width: 860px) {
+      .status-grid { grid-template-columns: 1fr; }
+      .item { grid-template-columns: 1fr; gap: 0.35rem; }
+    }
+  </style>
+</head>
+<body>
+  <main class="container">
+    <section class="hero">
+      <h1>Wyjazd służbowy do Chin (22–29.04.2026) – harmonogram live</h1>
+      <p class="sub">Strefa czasu: <strong>Asia/Shanghai (Pekin, UTC+8)</strong>. Widok aktualizuje się automatycznie co 10 minut i zaznacza aktualny oraz kolejny punkt.</p>
+      <p class="tiny" id="lastRefresh">Ostatnia aktualizacja: —</p>
+    </section>
+
+    <section class="status-grid">
+      <article class="card">
+        <span class="badge b-current">Aktualnie</span>
+        <h2 id="currentTitle">Poza aktywnymi punktami</h2>
+        <p class="tiny" id="currentTime">—</p>
+        <p class="tiny" id="currentDesc">Brak trwającego punktu harmonogramu.</p>
+      </article>
+      <article class="card">
+        <span class="badge b-next">Następnie</span>
+        <h2 id="nextTitle">—</h2>
+        <p class="tiny" id="nextTime">—</p>
+        <p class="tiny" id="nextDesc">—</p>
+      </article>
+      <article class="card">
+        <h2>Aktualny czas w Pekinie</h2>
+        <p class="tiny" id="beijingNow">—</p>
+        <p class="tiny">Automatyczne przeładowanie strony: co 10 min.</p>
+      </article>
+    </section>
+
+    <section class="timeline" id="timeline"></section>
+  </main>
+
+  <script>
+    const events = [
+      { d: '2026-04-22', day: 'Środa 22/04 – Beijing', t: '13:00', e: '13:30', title: 'Spotkanie w lobby + przejazd do Forbidden City', desc: 'Hotel Beijing International. Lunch przed spotkaniem. Zabierz paszport i wygodne buty.' },
+      { d: '2026-04-22', day: 'Środa 22/04 – Beijing', t: '13:30', e: '17:00', title: 'Zwiedzanie The Forbidden City', desc: 'Zwiedzanie z Lars Ulrik Thom (Beijing Postcards).' },
+      { d: '2026-04-22', day: 'Środa 22/04 – Beijing', t: '17:00', e: '17:30', title: 'Powrót autobusem do hotelu', desc: 'Odbiór przy North Gate. Z grupą jedzie James Xu.' },
+      { d: '2026-04-22', day: 'Środa 22/04 – Beijing', t: '17:30', e: '18:45', title: 'Czas własny', desc: '' },
+      { d: '2026-04-22', day: 'Środa 22/04 – Beijing', t: '18:45', e: '19:00', title: 'Spotkanie w lobby + dojazd na kolację', desc: 'Po kolacji możliwy spacer 1,5 km lub taxi.' },
+      { d: '2026-04-22', day: 'Środa 22/04 – Beijing', t: '19:00', e: '21:30', title: 'Kolacja: Da Dong Wangfujing', desc: 'Pekin duck + wprowadzenie do programu tygodnia.' },
+
+      { d: '2026-04-23', day: 'Czwartek 23/04 – Beijing', t: '08:25', e: '08:30', title: 'Spotkanie w lobby', desc: '' },
+      { d: '2026-04-23', day: 'Czwartek 23/04 – Beijing', t: '08:30', e: '10:00', title: 'Przejazd do Bytedance', desc: '' },
+      { d: '2026-04-23', day: 'Czwartek 23/04 – Beijing', t: '10:00', e: '12:00', title: 'Spotkanie z Bytedance (TikTok / Dongchedi)', desc: 'Experience center + spotkanie o ekosystemie i automotive leads.' },
+      { d: '2026-04-23', day: 'Czwartek 23/04 – Beijing', t: '12:00', e: '12:30', title: 'Lunch w Bytedance', desc: '' },
+      { d: '2026-04-23', day: 'Czwartek 23/04 – Beijing', t: '12:30', e: '13:30', title: 'Przejazd do JD.com', desc: '' },
+      { d: '2026-04-23', day: 'Czwartek 23/04 – Beijing', t: '13:30', e: '15:30', title: 'Spotkanie z JD.com (JD Automotive)', desc: 'Experience center + strategia e-commerce/logistyki/automotive.' },
+      { d: '2026-04-23', day: 'Czwartek 23/04 – Beijing', t: '15:30', e: '16:30', title: 'Powrót autobusem do hotelu', desc: '' },
+      { d: '2026-04-23', day: 'Czwartek 23/04 – Beijing', t: '16:30', e: '17:00', title: 'Czas własny', desc: '' },
+      { d: '2026-04-23', day: 'Czwartek 23/04 – Beijing', t: '17:00', e: '18:00', title: 'Dojazd na event networkingowy', desc: 'Jing A Wangjing Brewery.' },
+      { d: '2026-04-23', day: 'Czwartek 23/04 – Beijing', t: '18:00', e: '20:00', title: 'Networking (DCCC + German Chamber)', desc: 'Wystąpienia i networking.' },
+
+      { d: '2026-04-24', day: 'Piątek 24/04 – Beijing', t: '10:00', e: '10:45', title: 'Przejazd do WeRide', desc: '' },
+      { d: '2026-04-24', day: 'Piątek 24/04 – Beijing', t: '10:45', e: '11:30', title: 'WeRide: autonomiczna jazda', desc: 'Przejazd i omówienie technologii.' },
+      { d: '2026-04-24', day: 'Piątek 24/04 – Beijing', t: '11:30', e: '12:15', title: 'Shopping mall: ekspozycja i sprzedaż aut', desc: 'M.in. Xiaomi i Aito (Huawei).' },
+      { d: '2026-04-24', day: 'Piątek 24/04 – Beijing', t: '12:15', e: '12:30', title: 'Przejazd do restauracji', desc: '' },
+      { d: '2026-04-24', day: 'Piątek 24/04 – Beijing', t: '12:30', e: '13:40', title: 'Lunch', desc: 'Chińska restauracja.' },
+      { d: '2026-04-24', day: 'Piątek 24/04 – Beijing', t: '13:40', e: '14:00', title: 'Przejazd do CATL', desc: '' },
+      { d: '2026-04-24', day: 'Piątek 24/04 – Beijing', t: '14:00', e: '16:00', title: 'Spotkanie z CATL', desc: 'Baterie, storage, V2G, recykling i strategia europejska.' },
+      { d: '2026-04-24', day: 'Piątek 24/04 – Beijing', t: '16:00', e: '17:00', title: 'Powrót autobusem do hotelu', desc: '' },
+      { d: '2026-04-24', day: 'Piątek 24/04 – Beijing', t: '17:00', e: '17:55', title: 'Czas własny', desc: '' },
+      { d: '2026-04-24', day: 'Piątek 24/04 – Beijing', t: '17:55', e: '18:00', title: 'Spotkanie w lobby', desc: '' },
+      { d: '2026-04-24', day: 'Piątek 24/04 – Beijing', t: '18:00', e: '18:30', title: 'Spotkanie z przewodnikami food tour', desc: 'Przejazd do Hutong.' },
+      { d: '2026-04-24', day: 'Piątek 24/04 – Beijing', t: '18:30', e: '22:00', title: 'Beijing Hutong Food Tour', desc: '4 lokale, lokalna kuchnia, wieczór integracyjny.' },
+
+      { d: '2026-04-25', day: 'Sobota 25/04 – Beijing', t: '07:55', e: '08:00', title: 'Spotkanie w lobby', desc: 'Paszport, wygodne buty, krem z filtrem.' },
+      { d: '2026-04-25', day: 'Sobota 25/04 – Beijing', t: '08:00', e: '09:30', title: 'Przejazd do Great Wall (Badaling)', desc: '' },
+      { d: '2026-04-25', day: 'Sobota 25/04 – Beijing', t: '09:30', e: '10:00', title: 'Dystrybucja biletów + wejście', desc: '' },
+      { d: '2026-04-25', day: 'Sobota 25/04 – Beijing', t: '10:00', e: '12:00', title: 'Great Wall walk', desc: 'Spacer ok. 2h, opcja kolejki linowej.' },
+      { d: '2026-04-25', day: 'Sobota 25/04 – Beijing', t: '12:00', e: '14:00', title: 'Lunch', desc: 'Lunch przed powrotem do hotelu.' },
+      { d: '2026-04-25', day: 'Sobota 25/04 – Beijing', t: '14:00', e: '15:30', title: 'Powrót do hotelu', desc: '' },
+      { d: '2026-04-25', day: 'Sobota 25/04 – Beijing', t: '15:30', e: '18:30', title: 'Czas własny', desc: '' },
+      { d: '2026-04-25', day: 'Sobota 25/04 – Beijing', t: '18:30', e: '19:00', title: 'Wyjazd na kolację', desc: '' },
+      { d: '2026-04-25', day: 'Sobota 25/04 – Beijing', t: '19:00', e: '21:00', title: 'Kolacja: San Li Tun', desc: '' },
+
+      { d: '2026-04-26', day: 'Niedziela 26/04 – Beijing → Guangzhou', t: '08:15', e: '08:30', title: 'Spotkanie z walizkami w lobby', desc: 'Check-out i opłata mini baru przed spotkaniem.' },
+      { d: '2026-04-26', day: 'Niedziela 26/04 – Beijing → Guangzhou', t: '08:30', e: '09:30', title: 'Przejazd na Beijing Auto Show', desc: '' },
+      { d: '2026-04-26', day: 'Niedziela 26/04 – Beijing → Guangzhou', t: '09:30', e: '10:00', title: 'Wejście i bilety na Auto Show', desc: 'Mieć paszport.' },
+      { d: '2026-04-26', day: 'Niedziela 26/04 – Beijing → Guangzhou', t: '10:15', e: '10:45', title: 'Meeting 1: Leapmotor', desc: 'JV ze Stellantis, rozwój i ekspansja w Europie.' },
+      { d: '2026-04-26', day: 'Niedziela 26/04 – Beijing → Guangzhou', t: '11:00', e: '11:45', title: 'Meeting 2: Xiaomi', desc: 'Pozycjonowanie rynkowe i plany europejskie.' },
+      { d: '2026-04-26', day: 'Niedziela 26/04 – Beijing → Guangzhou', t: '12:00', e: '12:45', title: 'Meeting 3: NIO', desc: 'Strategia, technologie i battery swapping.' },
+      { d: '2026-04-26', day: 'Niedziela 26/04 – Beijing → Guangzhou', t: '12:45', e: '14:00', title: 'Czas własny na Auto Show', desc: 'Następnie spotkanie CADA.' },
+      { d: '2026-04-26', day: 'Niedziela 26/04 – Beijing → Guangzhou', t: '14:00', e: '15:15', title: 'Spotkanie z CADA', desc: 'Współpraca dealerów europejskich i chińskich.' },
+      { d: '2026-04-26', day: 'Niedziela 26/04 – Beijing → Guangzhou', t: '15:30', e: '16:00', title: 'Przejazd na lotnisko + check-in', desc: '' },
+      { d: '2026-04-26', day: 'Niedziela 26/04 – Beijing → Guangzhou', t: '19:15', e: '22:35', title: 'Lot CA1379: PEK → CAN', desc: 'Air China, Terminal 3 → Terminal 1.' },
+
+      { d: '2026-04-27', day: 'Poniedziałek 27/04 – Guangzhou → Shenzhen', t: '08:45', e: '09:00', title: 'Spotkanie w lobby', desc: 'Check-out i bagaże do autobusu.' },
+      { d: '2026-04-27', day: 'Poniedziałek 27/04 – Guangzhou → Shenzhen', t: '09:00', e: '10:00', title: 'Przejazd do Xpeng', desc: '' },
+      { d: '2026-04-27', day: 'Poniedziałek 27/04 – Guangzhou → Shenzhen', t: '10:00', e: '12:00', title: 'Spotkanie z Xpeng', desc: 'Experience center, EV, eVTOL, software, roboty IRON.' },
+      { d: '2026-04-27', day: 'Poniedziałek 27/04 – Guangzhou → Shenzhen', t: '12:00', e: '12:30', title: 'Lunch (sandwich)', desc: '' },
+      { d: '2026-04-27', day: 'Poniedziałek 27/04 – Guangzhou → Shenzhen', t: '12:30', e: '13:30', title: 'Przejazd do GAC Factory', desc: '' },
+      { d: '2026-04-27', day: 'Poniedziałek 27/04 – Guangzhou → Shenzhen', t: '13:30', e: '15:30', title: 'Spotkanie + factory tour GAC', desc: 'Inteligentna fabryka, AION, autonomia L2-L4.' },
+      { d: '2026-04-27', day: 'Poniedziałek 27/04 – Guangzhou → Shenzhen', t: '15:30', e: '17:30', title: 'Przejazd autobusem do Shenzhen', desc: '' },
+      { d: '2026-04-27', day: 'Poniedziałek 27/04 – Guangzhou → Shenzhen', t: '17:30', e: '19:15', title: 'Check-in + czas własny', desc: 'Shenzhen Shanghai Hotel.' },
+      { d: '2026-04-27', day: 'Poniedziałek 27/04 – Guangzhou → Shenzhen', t: '19:15', e: '19:30', title: 'Spotkanie w lobby + dojazd', desc: '' },
+      { d: '2026-04-27', day: 'Poniedziałek 27/04 – Guangzhou → Shenzhen', t: '19:30', e: '21:30', title: 'Kolacja: Terra Madre', desc: 'Włoska kolacja integracyjna.' },
+
+      { d: '2026-04-28', day: 'Wtorek 28/04 – Shenzhen', t: '08:55', e: '09:00', title: 'Spotkanie w lobby', desc: '' },
+      { d: '2026-04-28', day: 'Wtorek 28/04 – Shenzhen', t: '09:00', e: '10:00', title: 'Przejazd do Huawei', desc: '' },
+      { d: '2026-04-28', day: 'Wtorek 28/04 – Shenzhen', t: '10:00', e: '12:00', title: 'Spotkanie z Huawei', desc: 'Experience centre, AI, cloud, 5G, automotive.' },
+      { d: '2026-04-28', day: 'Wtorek 28/04 – Shenzhen', t: '12:00', e: '13:00', title: 'Lunch', desc: '' },
+      { d: '2026-04-28', day: 'Wtorek 28/04 – Shenzhen', t: '13:00', e: '14:00', title: 'Przejazd do UBTech', desc: '' },
+      { d: '2026-04-28', day: 'Wtorek 28/04 – Shenzhen', t: '14:00', e: '16:00', title: 'Wizyta w UBTech', desc: 'Spotkanie z managementem i demonstracje robotów humanoidalnych.' },
+      { d: '2026-04-28', day: 'Wtorek 28/04 – Shenzhen', t: '16:00', e: '17:00', title: 'Powrót do hotelu', desc: '' },
+      { d: '2026-04-28', day: 'Wtorek 28/04 – Shenzhen', t: '17:00', e: '18:45', title: 'Czas własny', desc: '' },
+      { d: '2026-04-28', day: 'Wtorek 28/04 – Shenzhen', t: '18:45', e: '19:00', title: 'Wyjście pieszo do restauracji', desc: '400 m.' },
+      { d: '2026-04-28', day: 'Wtorek 28/04 – Shenzhen', t: '19:00', e: '21:00', title: 'Farewell dinner: Xu’s Seafood', desc: 'Kuchnia kantońska.' },
+
+      { d: '2026-04-29', day: 'Środa 29/04 – Shenzhen', t: '09:55', e: '10:00', title: 'Spotkanie w lobby', desc: 'Check-out, możliwe pozostawienie bagażu.' },
+      { d: '2026-04-29', day: 'Środa 29/04 – Shenzhen', t: '10:00', e: '11:30', title: 'Huaqiangbei electronics market', desc: 'Spacer 550 m, czas na samodzielne zwiedzanie.' },
+      { d: '2026-04-29', day: 'Środa 29/04 – Shenzhen', t: '11:45', e: '12:00', title: 'Powrót i spotkanie w lobby', desc: '' },
+      { d: '2026-04-29', day: 'Środa 29/04 – Shenzhen', t: '12:00', e: '13:00', title: 'Lunch dostarczony dronami (Meituan)', desc: 'Strefa przy zatoce z widokiem na Hong Kong.' },
+      { d: '2026-04-29', day: 'Środa 29/04 – Shenzhen', t: '13:00', e: '14:00', title: 'Transport do BYD', desc: '' },
+      { d: '2026-04-29', day: 'Środa 29/04 – Shenzhen', t: '14:00', e: '16:00', title: 'Spotkanie z BYD', desc: 'Exhibition center, bateria, aftermarket, recykling, strategia łańcucha dostaw.' },
+      { d: '2026-04-29', day: 'Środa 29/04 – Shenzhen', t: '16:00', e: '17:00', title: 'Powrót po bagaże / transfery lotniskowe', desc: 'Część grupy jedzie bezpośrednio na lotnisko.' }
+    ];
+
+    function parseInChina(date, time) {
+      const [y, m, d] = date.split('-').map(Number);
+      const [hh, mm] = time.split(':').map(Number);
+      return Date.UTC(y, m - 1, d, hh - 8, mm, 0);
+    }
+
+    const normalized = events.map((ev, idx) => ({
+      ...ev,
+      start: parseInChina(ev.d, ev.t),
+      end: parseInChina(ev.d, ev.e),
+      idx
+    })).sort((a, b) => a.start - b.start);
+
+    function fmtChinaNow() {
+      return new Date().toLocaleString('pl-PL', {
+        timeZone: 'Asia/Shanghai',
+        weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+        hour: '2-digit', minute: '2-digit', second: '2-digit'
+      });
+    }
+
+    function findCurrentAndNext(nowMs) {
+      let current = null;
+      let next = null;
+
+      for (const ev of normalized) {
+        if (nowMs >= ev.start && nowMs < ev.end) {
+          current = ev;
+        }
+        if (ev.start > nowMs) {
+          next = ev;
+          break;
+        }
+      }
+
+      if (!next && current) {
+        const i = normalized.findIndex(e => e.idx === current.idx);
+        next = normalized[i + 1] || null;
+      }
+
+      return { current, next };
+    }
+
+    function buildTimeline(currentIdx, nextIdx) {
+      const byDay = normalized.reduce((acc, ev) => {
+        if (!acc[ev.day]) acc[ev.day] = [];
+        acc[ev.day].push(ev);
+        return acc;
+      }, {});
+
+      const wrapper = document.getElementById('timeline');
+      wrapper.innerHTML = '';
+
+      Object.entries(byDay).forEach(([day, list]) => {
+        const dayEl = document.createElement('article');
+        dayEl.className = 'day';
+
+        const head = document.createElement('div');
+        head.className = 'day-head';
+        head.textContent = day;
+
+        const items = document.createElement('div');
+        items.className = 'items';
+
+        list.forEach(ev => {
+          const item = document.createElement('div');
+          item.className = 'item';
+          if (ev.idx === currentIdx) item.classList.add('current-item');
+          if (ev.idx === nextIdx) item.classList.add('next-item');
+
+          item.innerHTML = `
+            <div class="time">${ev.t}–${ev.e}</div>
+            <div>
+              <div class="title">${ev.title}</div>
+              <p class="desc">${ev.desc || '—'}</p>
+            </div>
+          `;
+          items.appendChild(item);
+        });
+
+        dayEl.append(head, items);
+        wrapper.appendChild(dayEl);
+      });
+    }
+
+    function refreshView() {
+      const now = Date.now();
+      const { current, next } = findCurrentAndNext(now);
+
+      document.getElementById('beijingNow').textContent = fmtChinaNow();
+      document.getElementById('lastRefresh').textContent = `Ostatnia aktualizacja: ${fmtChinaNow()} (Pekin)`;
+
+      document.getElementById('currentTitle').textContent = current ? current.title : 'Poza aktywnymi punktami';
+      document.getElementById('currentTime').textContent = current ? `${current.day}, ${current.t}–${current.e}` : 'Teraz nie trwa żaden zaplanowany punkt.';
+      document.getElementById('currentDesc').textContent = current ? (current.desc || '—') : 'Sprawdź sekcję „Następnie”, aby zobaczyć kolejny punkt.';
+
+      document.getElementById('nextTitle').textContent = next ? next.title : 'Koniec harmonogramu';
+      document.getElementById('nextTime').textContent = next ? `${next.day}, ${next.t}–${next.e}` : 'Brak kolejnych punktów.';
+      document.getElementById('nextDesc').textContent = next ? (next.desc || '—') : 'Wyjazd zakończony zgodnie z harmonogramem.';
+
+      buildTimeline(current?.idx, next?.idx);
+    }
+
+    refreshView();
+    setInterval(refreshView, 60_000);
+    setInterval(() => window.location.reload(), 10 * 60 * 1000);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a standalone, mobile-friendly schedule page for the business trip to China (22–29 Apr 2026) that always shows the current and next scheduled item in Beijing local time. 
- Ensure the view refreshes automatically every 10 minutes (and recalculates status every minute) so participants see up-to-date positions in the itinerary. 
- Keep the page lightweight and readable on mobile devices and avoid adding it to the main site navigation as requested. 

### Description
- Added a new file `edc_site/chinatrip26.html` containing the full day-by-day itinerary extracted from the provided Google Doc and a responsive, minimal CSS layout. 
- Implemented client-side JavaScript that normalizes events into UTC (using Asia/Shanghai offsets), computes `current` and `next` items, highlights them in the timeline, and renders the per-day timeline. 
- Added live behavior that updates the status panel every minute with Beijing local time (`Asia/Shanghai`) and forces a full page reload every 10 minutes. 
- The page contains no changes to site navigation/menu and avoids heavy graphics to remain lightweight. 

### Testing
- Fetched the source Google Doc text using `curl -L 'https://docs.google.com/document/d/.../export?format=txt'` and saved it to `/tmp/china_trip.txt` (succeeded). 
- Committed the new page with `git` and verified the commit created `edc_site/chinatrip26.html` (commit succeeded). 
- Parsed the generated HTML with Python's `html.parser` to validate syntactic correctness using `python -c` script (HTML parsed successfully). 
- Inspected the file contents with `nl`/`sed` to verify the event list and scripts are present (inspection completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e8e789febc83308591155ba6c7c1df)