### PR TITLE
Update service worker (v2) and refresh UI/UX for chinatrip26 page

### DIFF
--- a/edc_site/chinatrip26-sw.js
+++ b/edc_site/chinatrip26-sw.js
@@ -1,11 +1,11 @@
-const CACHE_NAME = 'chinatrip26-v1';
-const ASSETS = [
+const CACHE_NAME = 'chinatrip26-v2';
+const APP_SHELL = [
   './chinatrip26.html',
   './chinatrip26.webmanifest'
 ];
 
 self.addEventListener('install', (event) => {
-  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS)));
+  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(APP_SHELL)));
   self.skipWaiting();
 });
 
@@ -18,16 +18,41 @@ self.addEventListener('activate', (event) => {
   self.clients.claim();
 });
 
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});
+
 self.addEventListener('fetch', (event) => {
   if (event.request.method !== 'GET') return;
+  const url = new URL(event.request.url);
+  const isDocumentRequest = event.request.mode === 'navigate' || event.request.destination === 'document';
+  const isChinaTripPage = url.pathname.endsWith('/chinatrip26') || url.pathname.endsWith('/chinatrip26.html');
+
+  if (isDocumentRequest || isChinaTripPage) {
+    event.respondWith(
+      fetch(new Request(event.request, { cache: 'no-store' }))
+        .then((response) => {
+          const copy = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put('./chinatrip26.html', copy));
+          return response;
+        })
+        .catch(() => caches.match('./chinatrip26.html'))
+    );
+    return;
+  }
+
   event.respondWith(
     caches.match(event.request).then((cached) => {
-      if (cached) return cached;
-      return fetch(event.request).then((response) => {
-        const copy = response.clone();
-        caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
-        return response;
-      }).catch(() => caches.match('./chinatrip26.html'));
+      const networkFetch = fetch(event.request)
+        .then((response) => {
+          const copy = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+          return response;
+        })
+        .catch(() => cached || caches.match('./chinatrip26.html'));
+      return cached || networkFetch;
     })
   );
 });

--- a/edc_site/chinatrip26.html
+++ b/edc_site/chinatrip26.html
@@ -45,7 +45,7 @@
       color: var(--text);
       background: linear-gradient(180deg, var(--bg-grad-1) 0%, var(--bg-grad-2) 100%);
       line-height: 1.45;
-      padding-top: 4.3rem;
+      padding-top: 3.5rem;
     }
 
     .container { width: min(1100px, 100% - 2rem); margin: 0 auto; padding: 1rem 0 2.5rem; }
@@ -54,40 +54,50 @@
 
     .floating-top {
       position: fixed;
-      top: .6rem;
+      top: .45rem;
       left: 50%;
       transform: translateX(-50%);
       width: min(1100px, calc(100% - 1.4rem));
       z-index: 50;
-      display: grid;
-      grid-template-columns: repeat(3, minmax(0, 1fr));
-      gap: .45rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: .55rem;
       background: color-mix(in srgb, var(--card), transparent 8%);
       border: 1px solid var(--line);
       border-radius: 12px;
-      padding: .5rem;
+      padding: .35rem .45rem;
       backdrop-filter: blur(8px);
       box-shadow: 0 8px 24px rgba(18, 34, 70, 0.12);
     }
+    .floating-line {
+      display: flex;
+      align-items: center;
+      gap: .5rem;
+      min-width: 0;
+      flex: 1;
+      overflow-x: auto;
+      white-space: nowrap;
+      scrollbar-width: thin;
+    }
     .floating-chip {
-      background: var(--accent-soft);
+      background: transparent;
       border: 1px solid var(--line);
       border-radius: 10px;
-      padding: .45rem .65rem;
+      padding: .22rem .5rem;
       min-width: 0;
+      display: inline-flex;
+      align-items: baseline;
+      gap: .35rem;
     }
     .floating-chip strong {
-      display: block;
-      font-size: .8rem;
+      display: inline;
+      font-size: .78rem;
       color: var(--muted);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
     }
     .floating-chip .floating-time {
-      font-size: 1.08rem;
+      font-size: 1rem;
       font-weight: 700;
-      margin-top: .1rem;
       letter-spacing: .02em;
     }
 
@@ -113,9 +123,10 @@
       border: 1px solid var(--line);
       background: var(--card);
       color: var(--text);
-      border-radius: 999px;
-      padding: .34rem .72rem;
-      font-size: .9rem;
+      border-radius: 10px;
+      padding: .28rem .5rem;
+      font-size: 1rem;
+      line-height: 1;
       cursor: pointer;
       user-select: none;
     }
@@ -173,16 +184,38 @@
       .status-grid { grid-template-columns: 1fr; }
       .item { grid-template-columns: 1fr; gap: .33rem; }
       .timeline-meta { flex-direction: column; align-items: flex-start; }
-      .floating-top { grid-template-columns: 1fr; padding: .4rem; }
-      body { padding-top: 9.5rem; }
+      .floating-top { padding: .3rem .35rem; }
+      body { padding-top: 3.6rem; }
     }
   </style>
 </head>
 <body>
   <section class="floating-top" aria-live="polite">
-    <div class="floating-chip"><strong id="clockBeijingLabel"></strong><div class="floating-time" id="beijingNow">—</div></div>
-    <div class="floating-chip"><strong id="clockBerlinLabel"></strong><div class="floating-time" id="berlinNow">—</div></div>
-    <div class="floating-chip"><strong id="topCountdownLabel"></strong><div class="floating-time" id="topCountdownValue">—</div></div>
+    <div class="floating-line">
+      <div class="floating-chip"><strong id="clockBeijingLabel"></strong><div class="floating-time" id="beijingNow">—</div></div>
+      <div class="floating-chip"><strong id="clockBerlinLabel"></strong><div class="floating-time" id="berlinNow">—</div></div>
+      <div class="floating-chip"><strong id="topCountdownLabel"></strong><div class="floating-time" id="topCountdownValue">—</div></div>
+    </div>
+    <details class="settings-menu">
+      <summary id="settingsSummaryIcon" aria-label="Settings menu">☰</summary>
+      <div class="settings-panel">
+        <div class="settings-group">
+          <span class="settings-label" id="langLabel"></span>
+          <div class="controls" id="langButtons"></div>
+        </div>
+        <div class="settings-group">
+          <span class="settings-label" id="fontLabel"></span>
+          <button id="fontDown" type="button">A−</button>
+          <button id="fontUp" type="button">A+</button>
+        </div>
+        <div class="settings-group">
+          <span class="settings-label" id="appearanceLabel"></span>
+          <button id="themeSystem" type="button">System</button>
+          <button id="themeLight" type="button">Light</button>
+          <button id="themeDark" type="button">Dark</button>
+        </div>
+      </div>
+    </details>
   </section>
   <main class="container">
     <section class="hero">
@@ -192,26 +225,6 @@
           <button id="enableAlerts" type="button"></button>
           <button id="exportIcs" type="button"></button>
         </div>
-        <details class="settings-menu">
-          <summary id="settingsSummary"></summary>
-          <div class="settings-panel">
-            <div class="settings-group">
-              <span class="settings-label" id="langLabel"></span>
-              <div class="controls" id="langButtons"></div>
-            </div>
-            <div class="settings-group">
-              <span class="settings-label" id="fontLabel"></span>
-              <button id="fontDown" type="button">A−</button>
-              <button id="fontUp" type="button">A+</button>
-            </div>
-            <div class="settings-group">
-              <span class="settings-label" id="appearanceLabel"></span>
-              <button id="themeSystem" type="button">System</button>
-              <button id="themeLight" type="button">Light</button>
-              <button id="themeDark" type="button">Dark</button>
-            </div>
-          </div>
-        </details>
       </div>
       <h1 id="pageTitle"></h1>
       <p class="sub" id="pageSub"></p>
@@ -417,7 +430,7 @@
       timeZone: tz, weekday: 'long', year: 'numeric', month: 'long', day: '2-digit', hour: '2-digit', minute:'2-digit', second:'2-digit'
     }).format(ms);
     const formatClock = (ms, locale, tz) => new Intl.DateTimeFormat(locale, {
-      timeZone: tz, hour: '2-digit', minute:'2-digit', second:'2-digit'
+      timeZone: tz, hour: '2-digit', minute:'2-digit', hour12: false
     }).format(ms);
 
     const formatDay = (d, city, locale) => `${new Intl.DateTimeFormat(locale, { weekday:'long', day:'2-digit', month:'2-digit' }).format(new Date(`${d}T00:00:00Z`))} — ${city}`;
@@ -551,7 +564,8 @@
       document.getElementById('themeSystem').textContent = copy.themeSystem;
       document.getElementById('themeLight').textContent = copy.themeLight;
       document.getElementById('themeDark').textContent = copy.themeDark;
-      document.getElementById('settingsSummary').textContent = copy.settings;
+      document.getElementById('settingsSummaryIcon').setAttribute('aria-label', copy.settings);
+      document.getElementById('settingsSummaryIcon').setAttribute('title', copy.settings);
       document.getElementById('langLabel').textContent = copy.language;
       document.getElementById('fontLabel').textContent = copy.fontSize;
       document.getElementById('appearanceLabel').textContent = copy.appearance;
@@ -684,7 +698,27 @@
     document.getElementById('exportIcs').addEventListener('click', downloadIcs);
 
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('./chinatrip26-sw.js').catch(() => {});
+      navigator.serviceWorker.register('./chinatrip26-sw.js').then((registration) => {
+        registration.update().catch(() => {});
+
+        if (registration.waiting) {
+          registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+        }
+
+        registration.addEventListener('updatefound', () => {
+          const worker = registration.installing;
+          if (!worker) return;
+          worker.addEventListener('statechange', () => {
+            if (worker.state === 'installed' && navigator.serviceWorker.controller) {
+              worker.postMessage({ type: 'SKIP_WAITING' });
+            }
+          });
+        });
+      }).catch(() => {});
+
+      navigator.serviceWorker.addEventListener('controllerchange', () => {
+        window.location.reload();
+      });
     }
 
     refreshView(true);


### PR DESCRIPTION
### Motivation
- Improve service worker lifecycle and caching to ensure the page shell is updated and served reliably for navigations and the main chinatrip page.
- Make the floating top bar more compact, scrollable and accessible while consolidating the settings into a single summary control.
- Normalize clock display to a 24-hour format and slightly tweak layout spacing for better visual balance on small screens.

### Description
- Bumped service worker cache to `chinatrip26-v2`, renamed `ASSETS` to `APP_SHELL`, and updated the `install`/`activate` handlers to use the new constant.
- Enhanced `fetch` handling in `chinatrip26-sw.js` to special-case document/navigation requests (always `fetch` with `no-store`, cache `./chinatrip26.html` and fallback to cached shell), and to use a cache-first with network-fallback strategy for other GET requests while caching successful network responses.
- Added SW `message` handler for `SKIP_WAITING` and updated page registration logic to `registration.update()`, post `SKIP_WAITING` to waiting/installed workers, and listen for `controllerchange` to reload the page so new SWs activate immediately.
- Moved the settings UI into the floating top bar, switched the floating container to `flex` with a scrollable `.floating-line`, simplified chip visuals, adjusted paddings and top offsets, and updated responsive `body` padding for small screens.
- Replaced the `settingsSummary` text element with `settingsSummaryIcon` and added `aria-label`/`title` attributes for accessibility.
- Modified `formatClock` to use 24-hour formatting (`hour12: false`) and removed seconds from the clock output.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e8fc44d9b483309f9bfe6a35076cb4)