### PR TITLE
Simplify /Chinatrip2026 by removing duplicated countdown/status text

### DIFF
--- a/edc_site/chinatrip26.html
+++ b/edc_site/chinatrip26.html
@@ -241,8 +241,6 @@
         </div>
       </div>
       <h1 id="pageTitle"></h1>
-      <p class="sub" id="pageSub"></p>
-      <p class="tiny" id="lastRefresh">—</p>
     </section>
 
     <section class="status-grid">
@@ -258,15 +256,9 @@
         <p class="tiny" id="nextTime">—</p>
         <p class="tiny" id="nextDesc">—</p>
       </article>
-      <article class="card">
-        <h2 id="countdownTitle"></h2>
-        <p class="tiny" id="countdownValue">—</p>
-        <p class="tiny" id="countdownHint">—</p>
-      </article>
     </section>
 
     <div class="timeline-meta">
-      <span class="chip" id="timelineCountdown"></span>
       <button type="button" id="togglePast"></button>
     </div>
 
@@ -548,22 +540,17 @@
       const copy = getCopy();
       const now = Date.now();
       const { current, next } = findCurrentAndNext(now);
-      const remaining = next ? fmtRemaining(next.start - now) : '0h 0m';
 
       document.documentElement.lang = lang;
       document.getElementById('pageTitle').textContent = copy.title;
-      document.getElementById('pageSub').textContent = copy.sub;
       document.getElementById('badgeCurrent').textContent = copy.current;
       document.getElementById('badgeNext').textContent = copy.next;
-      document.getElementById('countdownTitle').textContent = copy.countdown;
-      document.getElementById('countdownHint').textContent = copy.countdownHint;
       document.getElementById('clockBeijingLabel').textContent = copy.beijing;
       document.getElementById('clockBerlinLabel').textContent = copy.berlin;
       document.getElementById('topCountdownLabel').textContent = copy.shortCountdown;
       document.getElementById('beijingNow').textContent = formatClock(now, lang, 'Asia/Shanghai');
       document.getElementById('berlinNow').textContent = formatClock(now, lang, 'Europe/Berlin');
       document.getElementById('topCountdownValue').textContent = fmtCountdownClock(next ? next.start - now : 0);
-      document.getElementById('lastRefresh').textContent = `${copy.lastRefresh}: ${formatDate(now, lang, 'Asia/Shanghai')} (Beijing)`;
       document.getElementById('toggleNowNext').textContent = nowNextOnly ? copy.nowNextOnlyOn : copy.nowNextOnlyOff;
       document.getElementById('exportIcs').textContent = copy.exportIcs;
       const alertsBtn = document.getElementById('enableAlerts');
@@ -591,9 +578,6 @@
       document.getElementById('nextTitle').textContent = next ? next.title : copy.noNext;
       document.getElementById('nextTime').textContent = next ? `${formatDay(next.d, next.city, lang)} | ${next.t}–${next.e}` : copy.noNext;
       document.getElementById('nextDesc').textContent = next ? (next.desc || '—') : copy.noNextDesc;
-
-      document.getElementById('countdownValue').textContent = next ? `${remaining} (${copy.untilNext})` : copy.noNextDesc;
-      document.getElementById('timelineCountdown').textContent = next ? `${copy.untilNext}: ${remaining}` : copy.noNext;
 
       buildTimeline(current?.idx, next?.idx, now);
       scheduleUpcomingNotifications(now);


### PR DESCRIPTION
### Motivation
- The page showed duplicated status/countdown information (hero subtitle + last refresh, a countdown card, and a timeline chip), which cluttered the UI and repeated the same "time to next event" details.
- The intent is to keep only the top-bar next-event countdown and avoid repeating the same text in multiple places.

### Description
- Removed the hero subtitle (`#pageSub`) and the last-refresh line (`#lastRefresh`) from `edc_site/chinatrip26.html`.
- Removed the extra countdown card (elements `#countdownTitle`, `#countdownValue`, `#countdownHint`) from the status grid in `edc_site/chinatrip26.html`.
- Removed the duplicate timeline countdown chip (`#timelineCountdown`) from the timeline meta area.
- Updated `refreshView()` to stop writing to the removed DOM elements while keeping the top-bar countdown (`#topCountdownValue` / `shortCountdown`) intact.

### Testing
- Ran `rg -n "pageSub|lastRefresh|countdownTitle|countdownValue|countdownHint|timelineCountdown" edc_site/chinatrip26.html` to verify removed elements are no longer referenced in the page, and the search succeeded.
- Ran `rg -n "Timeline auto-updates every minute|Time to next event|Until next event|Always shown as hours and minutes|Timeline is aligned close to the next event|Last refresh" edc_site` to inspect related i18n strings, and the search succeeded.
- Committed the change and verified the commit with `git show --stat`, which reported one file changed (16 deletions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e9022bdc948330b8d6da1620b76029)