### PR TITLE
Set PWA reminders to 15 minutes before events

### DIFF
--- a/edc_site/chinatrip26.html
+++ b/edc_site/chinatrip26.html
@@ -725,9 +725,10 @@
     function scheduleUpcomingNotifications(nowMs) {
       if (!('Notification' in window) || Notification.permission !== 'granted') return;
       const horizonMs = 1000 * 60 * 60 * 12;
+      const reminderLeadMinutes = [15];
       normalized.forEach(ev => {
         if (ev.start < nowMs || ev.start - nowMs > horizonMs) return;
-        [30, 10].forEach(minBefore => {
+        reminderLeadMinutes.forEach(minBefore => {
           const fireAt = ev.start - (minBefore * 60 * 1000);
           if (fireAt <= nowMs) return;
           const key = `${ev.idx}-${minBefore}`;


### PR DESCRIPTION
### Motivation
- Ensure PWA push reminders for the China Trip schedule fire 15 minutes before each event instead of the previous multiple offsets.

### Description
- Replace the hardcoded `[30, 10]` offsets with a single configurable `reminderLeadMinutes = [15]` and iterate over it in `scheduleUpcomingNotifications` in `edc_site/chinatrip26.html` so only T-15 notifications are scheduled.

### Testing
- Ran `rg -n "reminderLeadMinutes|\[30, 10\]|T-" edc_site/chinatrip26.html` to verify the change and inspected the notification scheduling block, which showed the new `reminderLeadMinutes` usage (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e96eb456088330ad8dd460839d8101)