### PR TITLE
Add server-driven PWA update enforcement for China Trip 2026

### DIFF
--- a/edc_site/api/chinatrip26-version.php
+++ b/edc_site/api/chinatrip26-version.php
@@ -1,0 +1,30 @@
+<?php
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+header('Pragma: no-cache');
+header('Expires: 0');
+
+$root = dirname(__DIR__);
+$trackedFiles = [
+    $root . '/chinatrip26.html',
+    $root . '/chinatrip26.webmanifest',
+    $root . '/images/chinatrip26-icon.svg',
+    __FILE__,
+];
+
+$hashCtx = hash_init('sha256');
+foreach ($trackedFiles as $filePath) {
+    if (!is_readable($filePath)) {
+        continue;
+    }
+
+    hash_update($hashCtx, basename($filePath));
+    hash_update($hashCtx, (string)filemtime($filePath));
+    hash_update($hashCtx, (string)filesize($filePath));
+}
+
+$version = substr(hash_final($hashCtx), 0, 16);
+
+echo json_encode([
+    'version' => $version,
+]);

--- a/edc_site/chinatrip26-sw.js
+++ b/edc_site/chinatrip26-sw.js
@@ -1,4 +1,5 @@
-const CACHE_NAME = 'chinatrip26-v4';
+const VERSION = new URL(self.location.href).searchParams.get('v') || 'fallback';
+const CACHE_NAME = `chinatrip26-${VERSION}`;
 const APP_SHELL = [
   './chinatrip26.html',
   './chinatrip26.webmanifest',

--- a/edc_site/chinatrip26.html
+++ b/edc_site/chinatrip26.html
@@ -1648,8 +1648,19 @@
       }, { passive: true });
     }
 
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('./chinatrip26-sw.js').then((registration) => {
+    async function initServiceWorker() {
+      if (!('serviceWorker' in navigator)) return;
+
+      let swVersion = String(Date.now());
+      try {
+        const response = await fetch('./api/chinatrip26-version.php', { cache: 'no-store' });
+        if (response.ok) {
+          const payload = await response.json();
+          if (payload?.version) swVersion = payload.version;
+        }
+      } catch (_) {}
+
+      navigator.serviceWorker.register(`./chinatrip26-sw.js?v=${encodeURIComponent(swVersion)}`).then((registration) => {
         registration.update().catch(() => {});
 
         if (registration.waiting) {
@@ -1672,6 +1683,7 @@
       });
     }
 
+    initServiceWorker();
     setupPullToRefresh();
     refreshView(true);
     setInterval(() => refreshView(false), 60_000);

--- a/edc_site/vercel.json
+++ b/edc_site/vercel.json
@@ -3,5 +3,34 @@
     "api/*.php": {
       "runtime": "vercel-php@0.7.4"
     }
-  }
+  },
+  "headers": [
+    {
+      "source": "/chinatrip26-sw.js",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store, no-cache, must-revalidate, max-age=0"
+        }
+      ]
+    },
+    {
+      "source": "/chinatrip26.html",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/api/chinatrip26-version.php",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store, no-cache, must-revalidate, max-age=0"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
### Motivation
- Ensure already-installed PWA on iPhone and other platforms receives new app shell and offline content after deployments without users having to uninstall and reinstall the PWA.
- Avoid stale HTTP-cached responses for the service worker and version checks so update propagation is reliable across clients.

### Description
- Add `api/chinatrip26-version.php` which returns a no-cache JSON `version` token computed from key PWA files (`chinatrip26.html`, `chinatrip26.webmanifest`, icon and the endpoint) using SHA-256 metadata.
- Update `chinatrip26.html` to fetch the server `version` and register the Service Worker as `chinatrip26-sw.js?v=<version>` from a new `initServiceWorker()` function so clients load a distinct worker URL when content changes.
- Change `chinatrip26-sw.js` to read the `v` query parameter and scope caches to `chinatrip26-<version>`, causing old caches to be removed on activate and forcing fresh asset population for new versions.
- Add `vercel.json` headers to disable HTTP caching for `chinatrip26-sw.js` and the version endpoint and to set revalidation behavior for `chinatrip26.html` so servers and CDNs do not serve stale artifacts.

### Testing
- Ran `php -l edc_site/api/chinatrip26-version.php` and it reported no syntax errors.
- Ran `node --check edc_site/chinatrip26-sw.js` and the Service Worker file passed static JS syntax check.
- Ran `python -m json.tool edc_site/vercel.json` to validate JSON structure and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e97510af5c83308cb10affb0d60b55)