### PR TITLE
Localize More Info modal content and restrict EN-only entity info

### DIFF
--- a/edc_site/chinatrip26.html
+++ b/edc_site/chinatrip26.html
@@ -341,7 +341,7 @@
         refreshRate: 'Refresh rate', refreshSlow: 'Eco (5 min)', refreshMedium: 'Balanced (1 min)', refreshFast: 'Live (30 sec)',
         pushConsentText: 'Enable push alerts to avoid browser blocking reminders.',
         pushConsentEnable: 'Allow push alerts', pushConsentDismiss: 'Later',
-        moreInfo: '(i) More info'
+        moreInfo: '(i) More info', programContext: 'Program context'
       },
       pl: {
         flag: '🇵🇱', title: 'Wyjazd do Chin (22–29.04.2026) — harmonogram live',
@@ -361,7 +361,7 @@
         refreshRate: 'Częstotliwość odświeżania', refreshSlow: 'Eco (5 min)', refreshMedium: 'Standard (1 min)', refreshFast: 'Live (30 s)',
         pushConsentText: 'Włącz alerty push, aby przeglądarka nie blokowała przypomnień.',
         pushConsentEnable: 'Zezwól na push', pushConsentDismiss: 'Później',
-        moreInfo: '(i) Więcej informacji'
+        moreInfo: '(i) Więcej informacji', programContext: 'Kontekst programu'
       },
       hu: {
         flag: '🇭🇺', title: 'Kínai tanulmányút (2026. ápr. 22–29.) — élő program',
@@ -381,7 +381,7 @@
         refreshRate: 'Frissítési ütem', refreshSlow: 'Eco (5 perc)', refreshMedium: 'Normál (1 perc)', refreshFast: 'Live (30 mp)',
         pushConsentText: 'Engedélyezd a push értesítéseket, hogy a böngésző ne blokkolja az emlékeztetőket.',
         pushConsentEnable: 'Push engedélyezése', pushConsentDismiss: 'Később',
-        moreInfo: '(i) További információ'
+        moreInfo: '(i) További információ', programContext: 'Programkörnyezet'
       },
       da: {
         flag: '🇩🇰', title: 'Kina studietur (22.–29. apr. 2026) — live program',
@@ -401,7 +401,7 @@
         refreshRate: 'Opdateringsfrekvens', refreshSlow: 'Eco (5 min)', refreshMedium: 'Normal (1 min)', refreshFast: 'Live (30 sek)',
         pushConsentText: 'Aktivér push-alarmer, så browseren ikke blokerer påmindelser.',
         pushConsentEnable: 'Tillad push', pushConsentDismiss: 'Senere',
-        moreInfo: '(i) Mere info'
+        moreInfo: '(i) Mere info', programContext: 'Programkontekst'
       }
     };
 
@@ -1578,12 +1578,14 @@
 
           const descText = ev.desc || '—';
           const entity = detectEntity(ev);
-          const entityInfo = entity ? entity.info : '';
+          const entityInfo = entity && lang === 'en' ? entity.info : '';
           const titleText = entity ? `${entity.icon} ${ev.title}` : ev.title;
           const needsDetails = Boolean(entity) || isLongDesc(descText);
           const short = entity ? `${descText}${descText && descText !== '—' ? ' ' : ''}` : (needsDetails ? `${descText.split(/[.!?]/)[0]}.` : descText);
-          const detailsText = entity ? `${entityInfo}\n\n${descText && descText !== '—' ? `Program context: ${descText}` : ''}`.trim() : descText;
-          const detailsTitle = entity ? `${entity.title}` : ev.title;
+          const detailsText = entity
+            ? `${entityInfo}${entityInfo && descText && descText !== '—' ? '\n\n' : ''}${descText && descText !== '—' ? `${copy.programContext}: ${descText}` : ''}`.trim()
+            : descText;
+          const detailsTitle = ev.title;
 
           item.innerHTML = `
             <div class="time">${ev.t}–${ev.e}</div>


### PR DESCRIPTION
### Motivation
- Ensure the "More info" modal displays fully localized labels and content for all supported UI languages (`en`, `pl`, `hu`, `da`).
- Avoid showing English-only entity background text together with a localized program description, preventing mixed-language modal content.

### Description
- Added a new i18n key `programContext` to each supported locale in `edc_site/chinatrip26.html` (`en`, `pl`, `hu`, `da`).
- Updated the timeline details builder so the modal’s program-context label uses `copy.programContext` when composing details text.
- Changed entity background inclusion so `entity.info` is only appended when `lang === 'en'`, and non-English locales show only the localized event `desc` prefixed by the localized `programContext` label.
- Simplified the modal title assignment to always use the event title (`ev.title`).

### Testing
- Searched codebase to confirm i18n keys and usage with `rg -n "programContext|entityInfo = entity && lang === 'en'"` and verified the new keys and conditional appear in the file (passed).
- Inspected the modified sections with `sed`/`nl` to confirm the `programContext` strings and details-text construction changes are present (passed).
- Applied and verified the file patch with a Python script that updated `edc_site/chinatrip26.html` and printed confirmation (passed).
- Confirmed the repository working tree reports the `edc_site/chinatrip26.html` file as modified (status check passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ec02a34c8c8330ac50675b4e89b8fc)