### PR TITLE
Update China Trip 2026 map link to Beijing Auto Show halls image

### DIFF
--- a/edc_site/chinatrip26.html
+++ b/edc_site/chinatrip26.html
@@ -294,7 +294,7 @@
           <button id="toggleNowNext" type="button"></button>
           <button id="enableAlerts" type="button"></button>
           <button id="exportIcs" type="button"></button>
-          <a id="autoChinaMapLink" class="chip map-link" href="https://www.autochinashow.org/filedownload/2994429" target="_blank" rel="noopener noreferrer"></a>
+          <a id="autoChinaMapLink" class="chip map-link" href="http://www.beijingautoshow.com/wp-content/uploads/2026/04/halls.jpg" target="_blank" rel="noopener noreferrer"></a>
         </div>
       </div>
       <h1 id="pageTitle"></h1>


### PR DESCRIPTION
### Motivation
- Replace the previous Auto China download link with the requested Beijing Auto Show halls image so the China Trip 2026 page points to the correct map resource.

### Description
- Updated the `href` of the `autoChinaMapLink` anchor in `edc_site/chinatrip26.html` to `http://www.beijingautoshow.com/wp-content/uploads/2026/04/halls.jpg`.

### Testing
- No automated tests were run for this content-only HTML change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ed6816f4488330b2a18660fabb6bbb)