### PR TITLE
chinatrip26: hide past Flight live tile and add company websites/logos

### DIFF
--- a/edc_site/chinatrip26.html
+++ b/edc_site/chinatrip26.html
@@ -210,7 +210,24 @@
     .title { font-weight: 700; margin-bottom: .1rem; }
     .title-row { display: flex; align-items: center; gap: .4rem; flex-wrap: wrap; }
     .entity-icon { font-size: 1rem; }
+    .entity-logo {
+      width: 1.1rem;
+      height: 1.1rem;
+      object-fit: contain;
+      border-radius: 4px;
+      border: 1px solid color-mix(in srgb, var(--line), transparent 35%);
+      background: #fff;
+    }
     .desc { margin: .05rem 0; color: var(--muted); font-size: .9rem; }
+    .entity-meta {
+      margin-top: .35rem;
+      display: flex;
+      align-items: center;
+      gap: .4rem;
+      flex-wrap: wrap;
+    }
+    .entity-meta a { font-size: .82rem; color: var(--accent); text-decoration: none; }
+    .entity-meta a:hover { text-decoration: underline; }
     .status-list { list-style: none; margin: .35rem 0 0; padding: 0; display: grid; gap: .35rem; }
     .status-list li { display: flex; justify-content: space-between; gap: .6rem; font-size: .88rem; }
     .status-list li strong { color: var(--ink); font-weight: 700; }
@@ -306,7 +323,7 @@
     </section>
 
     <section class="status-grid">
-      <article class="card">
+      <article class="card" id="flightLiveCard">
         <span class="badge b-current" id="badgeCurrent"></span>
         <h2 id="currentTitle">—</h2>
         <p class="tiny" id="currentTime">—</p>
@@ -371,6 +388,7 @@
         pushConsentText: 'Enable push alerts to avoid browser blocking reminders.',
         pushConsentEnable: 'Allow push alerts', pushConsentDismiss: 'Later',
         moreInfo: '(i) More info', programContext: 'Program context',
+        companyWebsite: 'Website',
         flightLiveBadge: 'Flight live', flightStatusLabel: 'Status', flightGateLabel: 'Gate / Terminal',
         flightDelayLabel: 'Delay', flightLiveRefreshLabel: 'Last update',
         flightLinkTrack: 'Track flight', flightLinkCarrier: 'Air China',
@@ -397,6 +415,7 @@
         pushConsentText: 'Włącz alerty push, aby przeglądarka nie blokowała przypomnień.',
         pushConsentEnable: 'Zezwól na push', pushConsentDismiss: 'Później',
         moreInfo: '(i) Więcej informacji', programContext: 'Kontekst programu',
+        companyWebsite: 'Strona',
         flightLiveBadge: 'Lot na żywo', flightStatusLabel: 'Status', flightGateLabel: 'Gate / terminal',
         flightDelayLabel: 'Opóźnienie', flightLiveRefreshLabel: 'Aktualizacja',
         flightLinkTrack: 'Śledź lot', flightLinkCarrier: 'Air China',
@@ -423,6 +442,7 @@
         pushConsentText: 'Engedélyezd a push értesítéseket, hogy a böngésző ne blokkolja az emlékeztetőket.',
         pushConsentEnable: 'Push engedélyezése', pushConsentDismiss: 'Később',
         moreInfo: '(i) További információ', programContext: 'Programkörnyezet',
+        companyWebsite: 'Weboldal',
         flightLiveBadge: 'Élő járat', flightStatusLabel: 'Státusz', flightGateLabel: 'Gate / terminál',
         flightDelayLabel: 'Késés', flightLiveRefreshLabel: 'Frissítve',
         flightLinkTrack: 'Járatkövetés', flightLinkCarrier: 'Air China',
@@ -449,6 +469,7 @@
         pushConsentText: 'Aktivér push-alarmer, så browseren ikke blokerer påmindelser.',
         pushConsentEnable: 'Tillad push', pushConsentDismiss: 'Senere',
         moreInfo: '(i) Mere info', programContext: 'Programkontekst',
+        companyWebsite: 'Website',
         flightLiveBadge: 'Fly live', flightStatusLabel: 'Status', flightGateLabel: 'Gate / terminal',
         flightDelayLabel: 'Forsinkelse', flightLiveRefreshLabel: 'Sidst opdateret',
         flightLinkTrack: 'Spor fly', flightLinkCarrier: 'Air China',
@@ -1396,6 +1417,8 @@
         icon: '🏢',
         aliases: ['bytedance', 'tiktok', 'dongchedi'],
         title: 'ByteDance',
+        website: 'https://www.bytedance.com/en/',
+        logoUrl: 'https://logo.clearbit.com/bytedance.com',
         info: `ByteDance is a Beijing-founded technology company best known globally for TikTok and in China for products such as Douyin and Toutiao. Established in 2012, the company expanded rapidly by combining large-scale content platforms with recommendation algorithms optimized for user relevance and engagement. ByteDance’s ecosystem spans social media, short video, creator tools, enterprise software, and vertical products in areas such as automotive media through Dongchedi. Its growth model is often discussed as a case of product-led global expansion from China, with localized operations, data infrastructure, and regulatory adaptation in different regions. For business delegations, ByteDance is relevant not only as a media platform but also as a marketing and commerce channel that influences consumer discovery and purchase decisions. Automotive brands, dealers, and aftersales businesses increasingly use short-form video and live commerce formats to drive leads and brand positioning. At the same time, ByteDance is frequently part of policy debates around platform governance, privacy, algorithm transparency, and cross-border data compliance. A visit helps teams understand how digital ecosystems now shape demand generation, customer segmentation, and retail conversion in China’s fast-moving mobility market, where media, commerce, and software-enabled customer journeys are deeply integrated.`
       },
       {
@@ -1404,6 +1427,8 @@
         icon: '🏢',
         aliases: ['jd.com', 'jd automotive'],
         title: 'JD.com',
+        website: 'https://corporate.jd.com/',
+        logoUrl: 'https://logo.clearbit.com/jd.com',
         info: `JD.com is one of China’s largest technology-driven retail and supply-chain companies, headquartered in Beijing. The company began as an electronics retailer and evolved into a broad platform combining first-party retail, marketplace operations, logistics, cloud-enabled services, and data capabilities. A defining characteristic of JD is its long-term investment in infrastructure, including warehousing networks, fulfillment technology, and last-mile delivery systems, which support reliability and speed at national scale. For mobility and automotive participants, JD Automotive provides a useful reference for how digital channels connect consumers with vehicles, parts, accessories, maintenance services, and financing touchpoints. The company’s ecosystem demonstrates how e-commerce, logistics, and data analytics can compress the path from demand insight to inventory placement and final delivery. JD also illustrates China’s advanced experimentation with omnichannel retail, where online engagement, physical service nodes, and aftersales coordination are tightly linked. In strategy discussions, teams often focus on assortment planning, conversion optimization, and supply-chain resilience under rapid market shifts. Visiting JD helps delegation members compare platform-led retail models with dealership-led models and identify practical lessons in operational excellence, technology adoption, and customer experience design relevant to the European automotive distribution context.`
       },
       {
@@ -1412,6 +1437,8 @@
         icon: '🏢',
         aliases: ['weride', 'autonomous drive'],
         title: 'WeRide',
+        website: 'https://www.weride.ai/',
+        logoUrl: 'https://logo.clearbit.com/weride.ai',
         info: `WeRide is an autonomous driving technology company founded in China, focused on commercial deployment of self-driving solutions across multiple vehicle types and urban scenarios. The company is known for work in robotaxi services and has expanded into additional applications such as robobuses, logistics, and sanitation vehicles in selected markets. Its business relevance lies in translating advanced driverless research into real-world operations under regulatory constraints, mixed traffic environments, and safety requirements. For trip participants, WeRide offers a concrete view of how AI perception systems, mapping, fleet operations, and remote support infrastructure are integrated in daily service models. The company’s demonstrations typically highlight not only vehicle behavior but also the surrounding operational stack: dispatching, route design, compliance controls, and incident response protocols. Autonomous mobility in China is evolving through city-level pilots and partnerships among technology firms, automakers, and public authorities, making it a valuable case for policy and commercialization analysis. A WeRide session helps visitors evaluate timelines, cost structures, customer acceptance factors, and potential downstream effects on dealership service networks, insurance, fleet management, and urban transport planning as assisted and autonomous features become more mainstream.`
       },
       {
@@ -1420,6 +1447,8 @@
         icon: '🏢',
         aliases: ['catl'],
         title: 'CATL',
+        website: 'https://www.catl.com/en/',
+        logoUrl: 'https://logo.clearbit.com/catl.com',
         info: `CATL (Contemporary Amperex Technology Co. Limited) is one of the world’s most influential battery manufacturers and a central player in the global electric mobility value chain. Founded in 2011 and headquartered in Ningde, CATL supplies lithium-ion battery systems and energy-storage solutions to a broad range of automotive and industrial customers. The company is often referenced for scale manufacturing, chemistry innovation, pack integration, and vertical collaboration with automakers. In market strategy discussions, CATL is important because battery cost, performance, durability, and charging behavior directly shape EV competitiveness and consumer adoption. Beyond traction batteries, CATL’s portfolio includes stationary storage solutions that support grid flexibility and renewable integration, illustrating convergence between transport electrification and energy systems. For delegation teams, meetings at CATL can provide insights into roadmap planning, lifecycle management, recycling pathways, and cross-regional supply-chain localization. The company is also a practical case for understanding how Chinese industrial policy, engineering execution, and ecosystem partnerships accelerate time-to-market in critical clean-tech segments. Observing CATL’s approach helps visitors assess opportunities and risks in procurement strategy, technology dependency, and long-term cooperation models for European automotive distribution and service networks transitioning toward electrified fleets.`
       },
       {
@@ -1428,6 +1457,8 @@
         icon: '🏢',
         aliases: ['auto show', 'beijing auto show', 'auto china'],
         title: 'Auto China (Beijing Auto Show)',
+        website: 'http://www.beijingautoshow.com/',
+        logoUrl: 'https://logo.clearbit.com/beijingautoshow.com',
         info: `Auto China, commonly called the Beijing Auto Show, is one of the flagship automotive exhibitions in China and an important indicator of market direction in the global industry. Held on a biennial cycle, the event gathers domestic and international manufacturers, suppliers, technology firms, and media in a high-visibility format where product strategy and innovation narratives are publicly tested. The show is especially relevant today because Chinese brands increasingly set pace in electric drivetrains, software-defined vehicle features, connectivity, intelligent cockpit systems, and fast-charging ecosystems. For business delegations, Auto China functions as a dense learning environment: visitors can compare positioning across legacy OEMs, new-energy startups, and component partners in a single venue. Beyond vehicle launches, the event highlights trends in design language, pricing architecture, autonomous features, and digital user experiences that influence consumer expectations across markets. It also provides a useful lens on how policy, supply chains, and local competition shape commercialization speed in China. Structured walkthroughs help participants identify practical signals for product planning, retail adaptation, and partnership strategy in Europe, especially where electrification, software services, and new mobility propositions are rapidly changing dealership economics and customer journeys.`
       },
       {
@@ -1436,6 +1467,8 @@
         icon: '🏢',
         aliases: ['xiaomi'],
         title: 'Xiaomi',
+        website: 'https://www.mi.com/global/',
+        logoUrl: 'https://logo.clearbit.com/mi.com',
         info: `Xiaomi is a major Chinese technology company best known for smartphones, connected devices, and a broad consumer electronics ecosystem. In recent years, Xiaomi has expanded into electric vehicles, linking car software, smart devices, and cloud services into one user environment. This makes the company relevant for automotive retail because it shows how consumer-tech brands can enter mobility with strong digital communities, rapid product cycles, and integrated software experiences. For delegation teams, Xiaomi is a practical case for studying cross-industry convergence between electronics and vehicles.`
       },
       {
@@ -1444,6 +1477,8 @@
         icon: '🏢',
         aliases: ['nio'],
         title: 'NIO',
+        website: 'https://www.nio.com/',
+        logoUrl: 'https://logo.clearbit.com/nio.com',
         info: `NIO is a Chinese smart-EV company known for premium electric vehicles, software-centric user experiences, and battery swap services in selected markets. The company emphasizes digital engagement, branded owner communities, and service innovation around charging and energy flexibility. For business visitors, NIO is useful as a case study in how product, brand experience, and infrastructure can be designed together. Its approach helps teams think about customer loyalty, subscription-style services, and the operational implications of energy ecosystems for dealers and aftersales partners.`
       },
       {
@@ -1452,6 +1487,8 @@
         icon: '🏢',
         aliases: ['xpeng'],
         title: 'XPENG',
+        website: 'https://www.xpeng.com/',
+        logoUrl: 'https://logo.clearbit.com/xpeng.com',
         info: `XPENG is a Chinese electric-vehicle manufacturer focused on smart mobility, advanced driver-assistance capabilities, and software-defined product architecture. The brand has become a visible player in China’s fast-moving EV competition and is expanding internationally with selected models. Delegation participants often look at XPENG to understand rapid iteration in cockpit software, connectivity, and intelligent-driving features. The company is relevant for distribution strategy because it illustrates how digital feature roadmaps and OTA updates can influence perceived product value over time.`
       },
       {
@@ -1460,6 +1497,8 @@
         icon: '🏢',
         aliases: ['gac'],
         title: 'GAC Group',
+        website: 'https://www.gac.com.cn/en/',
+        logoUrl: 'https://logo.clearbit.com/gac.com.cn',
         info: `GAC Group (Guangzhou Automobile Group) is a large Chinese automotive manufacturer with activities across vehicle production, R&D, component supply, and strategic partnerships. The group includes established brands and new-energy initiatives and is often discussed as an example of how large incumbents adapt to electrification and intelligent mobility. A factory visit is valuable for seeing operational scale, process engineering, and quality systems in practice. For European delegates, GAC offers perspective on manufacturing competitiveness and platform strategy in China’s industrial ecosystem.`
       },
       {
@@ -1468,6 +1507,8 @@
         icon: '🏢',
         aliases: ['huawei', 'aito'],
         title: 'Huawei',
+        website: 'https://www.huawei.com/en/',
+        logoUrl: 'https://logo.clearbit.com/huawei.com',
         info: `Huawei is a global technology company headquartered in Shenzhen, with capabilities spanning telecommunications, enterprise digital infrastructure, cloud services, and consumer devices. In automotive contexts, Huawei is increasingly visible through intelligent cockpit, connectivity, and assisted-driving technology collaborations with carmakers. This makes Huawei relevant to market observers tracking how ICT companies reshape vehicle architecture and customer experience. For delegation members, meetings can provide insight into software-hardware integration, platform ecosystems, and the growing role of digital infrastructure in automotive value creation.`
       },
       {
@@ -1476,6 +1517,8 @@
         icon: '🏢',
         aliases: ['ubtech'],
         title: 'UBTECH Robotics',
+        website: 'https://www.ubtrobot.com/en/',
+        logoUrl: 'https://logo.clearbit.com/ubtrobot.com',
         info: `UBTECH Robotics is a Shenzhen-based robotics company known for humanoid and service-robot development. The firm works on motion control, AI-enabled interaction, and robotics applications across education, enterprise, and industrial scenarios. For automotive-focused delegations, UBTECH is relevant because robotics increasingly intersects with manufacturing, logistics, and customer-facing digital experiences. A visit helps participants evaluate where humanoid and collaborative robot technologies may create practical value, what deployment barriers remain, and how automation strategy connects to workforce and process design.`
       },
       {
@@ -1484,6 +1527,8 @@
         icon: '🏢',
         aliases: ['byd'],
         title: 'BYD',
+        website: 'https://www.byd.com/',
+        logoUrl: 'https://logo.clearbit.com/byd.com',
         info: `BYD is one of China’s leading new-energy mobility companies and a major global EV producer. Founded in the battery sector and later expanded into vehicles, BYD is frequently cited for vertical integration, scale execution, and rapid product rollout. The company’s portfolio spans passenger cars, commercial vehicles, and energy-related technologies. For delegation teams, BYD provides a strong benchmark for cost structure, battery strategy, and market positioning in high-volume EV competition. It is also useful for understanding how industrial integration can accelerate innovation speed.`
       },
       {
@@ -1492,6 +1537,8 @@
         icon: '🏢',
         aliases: ['cada'],
         title: 'CADA',
+        website: 'http://www.cada.cn/',
+        logoUrl: 'https://logo.clearbit.com/cada.cn',
         info: `CADA, the China Automobile Dealers Association, is an industry organization representing automotive circulation and dealership stakeholders in China. It plays a role in market dialogue, sector coordination, and information exchange across the distribution ecosystem. For international groups, CADA sessions are valuable for understanding dealer economics, used-car development, policy trends, and channel transformation in a rapidly electrifying market. The association perspective complements OEM and technology visits by adding a distribution-level view of competition and customer behavior.`
       },
       {
@@ -1500,6 +1547,8 @@
         icon: '🏢',
         aliases: ['leapmotor'],
         title: 'Leapmotor',
+        website: 'https://www.leapmotor.com/',
+        logoUrl: 'https://logo.clearbit.com/leapmotor.com',
         info: `Leapmotor is a Chinese EV manufacturer focused on cost-efficient smart electric vehicles and in-house development of selected core components. The company is often discussed as part of the new wave of high-speed EV challengers that compete through digital features and value-focused positioning. Delegation participants can use Leapmotor as a reference point for product strategy under intense domestic competition. It helps illustrate how brands balance technology claims, affordability, manufacturing pace, and channel expansion in China’s dynamic market environment.`
       },
       {
@@ -1516,6 +1565,8 @@
         icon: '🏢',
         aliases: ['dccc', 'german chamber'],
         title: 'DCCC & German Chamber',
+        website: 'https://www.dccc.com.cn/',
+        logoUrl: 'https://logo.clearbit.com/dccc.com.cn',
         info: `The Danish-Chinese Chamber of Commerce (DCCC) and the German Chamber network in China are business organizations that support market entry, peer networking, and policy dialogue for international companies operating in China. Events with these organizations typically combine practical market intelligence with executive-level exchange across industries. For delegation participants, such sessions are useful for understanding on-the-ground business conditions, regulatory expectations, partner selection risks, and operational lessons learned from companies already active in the Chinese market.`
       },
       {
@@ -1656,6 +1707,7 @@
       const hay = `${ev.title} ${ev.desc || ''}`.toLowerCase();
       return entityCatalog.find((entity) => entity.aliases.some((alias) => hay.includes(alias)));
     };
+    const getFlightEvent = () => eventsEn.find((ev) => ev.title.includes('Flight CA1379'));
 
     function openDetails(title, text) {
       const copy = getCopy();
@@ -1703,15 +1755,23 @@
           const needsDetails = Boolean(entity) || isLongDesc(descText);
           const short = entity ? `${descText}${descText && descText !== '—' ? ' ' : ''}` : (needsDetails ? `${descText.split(/[.!?]/)[0]}.` : descText);
           const detailsText = entity
-            ? `${entityInfo}${entityInfo && descText && descText !== '—' ? '\n\n' : ''}${descText && descText !== '—' ? `${copy.programContext}: ${descText}` : ''}`.trim()
+            ? `${entityInfo}${entity?.type === 'company' && entity?.website ? `\n\n${copy.companyWebsite}: ${entity.website}` : ''}${entityInfo && descText && descText !== '—' ? '\n\n' : ''}${descText && descText !== '—' ? `${copy.programContext}: ${descText}` : ''}`.trim()
             : descText;
           const detailsTitle = ev.title;
+          const safeLogoTitle = entity?.title ? entity.title.replace(/"/g, '&quot;') : '';
+          const companyMeta = entity?.type === 'company' && entity?.website
+            ? `<div class="entity-meta">${entity.logoUrl ? `<img class="entity-logo" src="${entity.logoUrl}" alt="${safeLogoTitle} logo" loading="lazy" decoding="async" referrerpolicy="no-referrer" />` : ''}<a href="${entity.website}" target="_blank" rel="noopener noreferrer">${copy.companyWebsite}: ${entity.website}</a></div>`
+            : '';
+          const companyLogoInTitle = entity?.type === 'company' && entity?.logoUrl
+            ? `<img class="entity-logo" src="${entity.logoUrl}" alt="${safeLogoTitle} logo" loading="lazy" decoding="async" referrerpolicy="no-referrer" />`
+            : '';
 
           item.innerHTML = `
             <div class="time">${ev.t}–${ev.e}</div>
             <div>
-              <div class="title title-row"><span>${titleText}</span></div>
+              <div class="title title-row">${companyLogoInTitle}<span>${titleText}</span></div>
               <p class="desc">${short}</p>
+              ${companyMeta}
               ${needsDetails ? `<button type="button" class="info-link details-btn">${copy.moreInfo}</button>` : ''}
             </div>
           `;
@@ -1815,6 +1875,7 @@
       document.getElementById('flightLiveRefreshLabel').textContent = copy.flightLiveRefreshLabel;
       document.getElementById('flightLinkTrack').textContent = copy.flightLinkTrack;
       document.getElementById('flightLinkCarrier').textContent = copy.flightLinkCarrier;
+      updateFlightCardVisibility(now);
       renderFlightLiveCard();
       const pullRefreshStatus = document.getElementById('pullRefreshStatus');
       if (pullRefreshStatus && !pullRefreshStatus.classList.contains('visible')) pullRefreshStatus.textContent = copy.pullToRefreshHint;
@@ -1865,6 +1926,18 @@
       document.getElementById('flightGateValue').textContent = gateText;
       document.getElementById('flightDelayValue').textContent = delayText;
       document.getElementById('flightLiveRefreshValue').textContent = formatFlightUpdateTime(flightLiveState.updatedAtIso);
+    }
+
+    function updateFlightCardVisibility(nowMs) {
+      const flightCard = document.getElementById('flightLiveCard');
+      if (!flightCard) return;
+      const flightEvent = getFlightEvent();
+      if (!flightEvent) {
+        flightCard.style.display = '';
+        return;
+      }
+      const flightEndMs = parseInChina(flightEvent.d, flightEvent.e);
+      flightCard.style.display = nowMs > flightEndMs ? 'none' : '';
     }
 
     async function refreshFlightLiveStatus() {


### PR DESCRIPTION
### Motivation
- Automatically hide the "Flight live" card when the tracked flight (CA1379) has ended so the dashboard doesn't show stale live status for past flights. 
- Enrich timeline entries for company visits with the company's website and logo to provide quick reference and consistent branding in event details.

### Description
- Add `id="flightLiveCard"` and an `updateFlightCardVisibility(now)` function that hides the flight card when `now` is after the flight event end (uses `getFlightEvent()` and existing `parseInChina()` time logic). 
- Add `website` and `logoUrl` fields to company entries in `entityCatalog` for all company-linked entities and load logos via `logo.clearbit.com` (no asset bundling). 
- Render company `logoUrl` next to the title and a clickable website link below the description using new CSS classes `entity-logo` and `entity-meta`. 
- Include the company website line in the details modal text and add an i18n label `companyWebsite` for EN/PL/HU/DA. 
- Minor JS safety/UX choices: use `loading="lazy"`, `decoding="async"`, `referrerpolicy="no-referrer"` for external logo images.

### Testing
- Ran a basic content smoke check with `python` assertions that validated `id="flightLiveCard"` and presence of `const getFlightEvent`; the script printed `basic checks passed` (success). 
- Attempted to run `xmllint --html` to validate markup, but `xmllint` is not installed in the environment (tool unavailable). 
- Manual static diff/grep inspection was used to confirm inserted `website`/`logoUrl` entries and new template code for rendering logos and links (no runtime browser test in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ef2e1f089483309cdbc679b62c361d)