### PR TITLE
Update Apr 28 itinerary to Pony.ai and hide live flight tracker

### DIFF
--- a/edc_site/chinatrip26.html
+++ b/edc_site/chinatrip26.html
@@ -323,7 +323,7 @@
     </section>
 
     <section class="status-grid">
-      <article class="card" id="flightLiveCard" hidden>
+      <article class="card" hidden>
         <span class="badge b-current" id="badgeCurrent"></span>
         <h2 id="currentTitle">—</h2>
         <p class="tiny" id="currentTime">—</p>
@@ -335,7 +335,7 @@
         <p class="tiny" id="nextTime">—</p>
         <p class="tiny" id="nextDesc">—</p>
       </article>
-      <article class="card">
+      <article class="card" id="flightLiveCard" hidden>
         <span class="badge" id="flightLiveBadge">Flight live</span>
         <h2 id="flightLiveTitle">CA1379 • PEK → CAN</h2>
         <ul class="status-list">
@@ -948,7 +948,7 @@
             "city": "Shenzhen",
             "t": "09:00",
             "e": "10:00",
-            "title": "Transfer to Huawei",
+            "title": "Transfer to Pony.ai",
             "desc": ""
       },
       {
@@ -956,8 +956,8 @@
             "city": "Shenzhen",
             "t": "10:00",
             "e": "12:00",
-            "title": "Meeting with Huawei",
-            "desc": "Experience center, AI, cloud, 5G and automotive."
+            "title": "Meeting with Pony.ai",
+            "desc": "Autonomous driving, robotaxi operations, AI and fleet management."
       },
       {
             "d": "2026-04-28",
@@ -1137,7 +1137,7 @@
             "Meeting 3: NIO": "Spotkanie 3: NIO",
             "Meeting with BYD": "Spotkanie z BYD",
             "Meeting with CADA": "Spotkanie z CADĄ",
-            "Meeting with Huawei": "Spotkanie z Huaweiem",
+            "Meeting with Pony.ai": "Spotkanie z Pony.ai",
             "Meeting with Xpeng": "Spotkanie z Xpengiem",
             "Meeting: Bytedance (TikTok / Dongchedi)": "Spotkanie: Bytedance (TikTok / Dongchedi)",
             "Meeting: CATL": "Spotkanie: CATL",
@@ -1166,7 +1166,7 @@
             "Transfer to CATL": "Przejazd do CATL",
             "Transfer to GAC Factory": "Przeniesienie do fabryki GAC",
             "Transfer to Great Wall (Badaling)": "Przejazd do Wielkiego Muru (Badaling)",
-            "Transfer to Huawei": "Przelew do Huawei",
+            "Transfer to Pony.ai": "Transfer do Pony.ai",
             "Transfer to Hutong area.": "Transfer do rejonu Hutong.",
             "Transfer to JD.com": "Przenieś na JD.com",
             "Transfer to UBTech": "Przeniesienie do UBTechu",
@@ -1243,7 +1243,7 @@
             "Meeting 3: NIO": "3. találkozó: NIO",
             "Meeting with BYD": "Találkozó a BYD-vel",
             "Meeting with CADA": "Találkozó a CADA-val",
-            "Meeting with Huawei": "Találkozás a Huawei-vel",
+            "Meeting with Pony.ai": "Találkozó a Pony.ai-jal",
             "Meeting with Xpeng": "Találkozás Xpenggel",
             "Meeting: Bytedance (TikTok / Dongchedi)": "Találkozó: Bytedance (TikTok / Dongchedi)",
             "Meeting: CATL": "Találkozó: CATL",
@@ -1272,7 +1272,7 @@
             "Transfer to CATL": "Transzfer a CATL-hez",
             "Transfer to GAC Factory": "Transzfer a GAC ​​gyárba",
             "Transfer to Great Wall (Badaling)": "Transzfer a Nagy Falhoz (Badaling)",
-            "Transfer to Huawei": "Transzfer a Huaweihez",
+            "Transfer to Pony.ai": "Transzfer a Pony.ai-hoz",
             "Transfer to Hutong area.": "Transzfer Hutong területére.",
             "Transfer to JD.com": "Transzfer a JD.com oldalra",
             "Transfer to UBTech": "Transzfer az UTBech-hez",
@@ -1349,7 +1349,7 @@
             "Meeting 3: NIO": "Møde 3: NIO",
             "Meeting with BYD": "Møde med BYD",
             "Meeting with CADA": "Møde med CADA",
-            "Meeting with Huawei": "Møde med Huawei",
+            "Meeting with Pony.ai": "Møde med Pony.ai",
             "Meeting with Xpeng": "Møde med Xpeng",
             "Meeting: Bytedance (TikTok / Dongchedi)": "Møde: Bytedance (TikTok / Dongchedi)",
             "Meeting: CATL": "Møde: CATL",
@@ -1378,7 +1378,7 @@
             "Transfer to CATL": "Overførsel til CATL",
             "Transfer to GAC Factory": "Overførsel til GAC Factory",
             "Transfer to Great Wall (Badaling)": "Overførsel til Great Wall (Badaling)",
-            "Transfer to Huawei": "Overfør til Huawei",
+            "Transfer to Pony.ai": "Overfør til Pony.ai",
             "Transfer to Hutong area.": "Transfer til Hutong-området.",
             "Transfer to JD.com": "Overfør til JD.com",
             "Transfer to UBTech": "Overførsel til UBTech",


### PR DESCRIPTION
### Motivation
- The Shenzhen itinerary on 2026-04-28 was updated to reflect a schedule change from Huawei to Pony.ai for the 09:00–10:00 transfer and 10:00 meeting. 
- The live flight tracker card was appearing after the flight ended, so visibility logic needed to target the correct DOM element and keep the card hidden by default.
- Localized labels must match the new itinerary entries so translations display correctly.

### Description
- Replaced the April 28 `Transfer to Huawei` and `Meeting with Huawei` entries with `Transfer to Pony.ai` and `Meeting with Pony.ai` and updated the meeting description to: "Autonomous driving, robotaxi operations, AI and fleet management." in `edc_site/chinatrip26.html`.
- Moved the `id="flightLiveCard"` attribute to the actual flight tracker card element and ensured it is rendered with `hidden` by default so the existing visibility logic hides it when the flight has ended.
- Updated translation keys/mappings for the new `Meeting with Pony.ai` and `Transfer to Pony.ai` labels in the Polish, Hungarian and Danish sections of the copy bundle.

### Testing
- Ran `rg -n "Transfer to Pony.ai|Meeting with Pony.ai|flightLiveCard" edc_site/chinatrip26.html` to assert the new strings and the `flightLiveCard` id are present; the search returned the expected locations.
- Inspected the updated `edc_site/chinatrip26.html` segments with line-numbered output to confirm the flight card now has `id="flightLiveCard"` and `hidden` and that the April 28 entries show the Pony.ai changes; inspection succeeded.
- Verified the HTML rendering logic references the same `flightLiveCard` id used by the visibility and refresh code paths by checking the file for the corresponding JS usages; verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f0101c33a88330b625e854afc3b4ca)